### PR TITLE
Reduce floating point errors

### DIFF
--- a/packages/tidy/src/helpers/summation.test.ts
+++ b/packages/tidy/src/helpers/summation.test.ts
@@ -1,0 +1,49 @@
+import { sum, cumsum, mean } from './summation';
+
+const data = [1, 2, 3, 4, 5];
+const badData = [NaN, null, undefined, ...data, NaN, null, undefined];
+
+describe('sum', () => {
+  it('it works with no accessor', () => {
+    expect(sum(data)).toEqual(15);
+  });
+  it('it ignores nullish', () => {
+    expect(sum(data)).toEqual(sum(badData));
+  });
+  it('it works with accessor', () => {
+    expect(sum(data, (d) => d + 1)).toEqual(20);
+    expect(sum(data, (d, i) => d + i)).toEqual(25);
+  });
+});
+
+describe('cumsum', () => {
+  it('it works with no accessor', () => {
+    expect(cumsum(data)).toEqual(Float64Array.from([1, 3, 6, 10, 15]));
+  });
+  it('it ignores nullish', () => {
+    expect(cumsum(badData)).toEqual(
+      Float64Array.from([0, 0, 0, 1, 3, 6, 10, 15, 15, 15, 15])
+    );
+  });
+  it('it works with accessor', () => {
+    expect(cumsum(data, (d) => d + 1)).toEqual(
+      Float64Array.from([2, 5, 9, 14, 20])
+    );
+    expect(cumsum(data, (d, i) => d + i)).toEqual(
+      Float64Array.from([1, 4, 9, 16, 25])
+    );
+  });
+});
+
+describe('mean', () => {
+  it('it works with no accessor', () => {
+    expect(mean(data)).toEqual(3);
+  });
+  it('it ignores nullish', () => {
+    expect(mean(badData)).toEqual(3);
+  });
+  it('it works with accessor', () => {
+    expect(mean(data, (d) => d + 1)).toEqual(4);
+    expect(mean(data, (d, i) => d + i)).toEqual(5);
+  });
+});

--- a/packages/tidy/src/helpers/summation.ts
+++ b/packages/tidy/src/helpers/summation.ts
@@ -1,0 +1,112 @@
+/**
+ * These functions compute the sum, cumsum, and mean of an array with the same API as d3-array
+ * instead of using a plain sum, they use the "improved Kahan-Babuška summation algorithm" to
+ * correct some of the floating point error:
+ * https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements
+ * originally from page 40 of https://www.mat.univie.ac.at/~neum/scan/01.pdf
+ */
+export function sum<T>(
+  items: T[],
+  accessor?: (element: T, i: number, array: Iterable<T>) => any
+): number {
+  let sum: number = 0,
+    correction: number = 0,
+    temp: number = 0;
+
+  for (let i = 0; i < items.length; i++) {
+    let value: number =
+      accessor === undefined ? items[i] : accessor(items[i], i, items);
+
+    if (+value !== value) {
+      value = 0;
+    }
+
+    if (i === 0) {
+      sum = value;
+    } else {
+      temp = sum + value;
+
+      if (Math.abs(sum) >= Math.abs(value)) {
+        correction += sum - temp + value;
+      } else {
+        correction += value - temp + sum;
+      }
+
+      sum = temp;
+    }
+  }
+  return sum + correction;
+}
+
+export function cumsum<T>(
+  items: T[],
+  accessor?: (element: T, i: number, array: Iterable<T>) => any
+): Float64Array {
+  let sum: number = 0,
+    correction: number = 0,
+    temp: number = 0,
+    cumsums: Float64Array = new Float64Array(items.length);
+  for (let i = 0; i < items.length; i++) {
+    let value: number =
+      accessor === undefined ? items[i] : accessor(items[i], i, items);
+
+    if (+value !== value) {
+      value = 0;
+    }
+
+    if (i === 0) {
+      sum = value;
+    } else {
+      temp = sum + value;
+
+      if (Math.abs(sum) >= Math.abs(value)) {
+        correction += sum - temp + value;
+      } else {
+        correction += value - temp + sum;
+      }
+
+      sum = temp;
+    }
+
+    cumsums[i] = sum + correction;
+  }
+
+  return cumsums;
+}
+
+export function mean<T>(
+  items: T[],
+  accessor?: (element: T, i: number, array: Iterable<T>) => any
+): number | undefined {
+  let n: number = 0,
+    sum: number = 0,
+    correction: number = 0,
+    temp: number = 0;
+
+  for (let i = 0; i < items.length; i++) {
+    let value: number =
+      accessor === undefined ? items[i] : accessor(items[i], i, items);
+
+    if (+value !== value) {
+      value = 0;
+    } else {
+      n++;
+    }
+
+    if (i === 0) {
+      sum = value;
+    } else {
+      temp = sum + value;
+
+      if (Math.abs(sum) >= Math.abs(value)) {
+        correction += sum - temp + value;
+      } else {
+        correction += value - temp + sum;
+      }
+
+      sum = temp;
+    }
+  }
+
+  return n ? (sum + correction) / n : undefined;
+}

--- a/packages/tidy/src/mutateWithSummary.ts
+++ b/packages/tidy/src/mutateWithSummary.ts
@@ -7,6 +7,8 @@ export type ResolvedObj<Obj extends Record<Key, MutateSpecValue<any>>> = {
   [K in keyof Obj]: Obj[K] extends (...args: any) => any
     ? ReturnType<Obj[K]> extends any[]
       ? ReturnType<Obj[K]>[number]
+      : ReturnType<Obj[K]> extends Float64Array
+      ? number
       : ReturnType<Obj[K]>
     : Obj[K];
 };

--- a/packages/tidy/src/summary/mean.ts
+++ b/packages/tidy/src/summary/mean.ts
@@ -1,4 +1,4 @@
-import { mean as d3mean } from 'd3-array';
+import { mean as meanInternal } from '../helpers/summation';
 
 /**
  * Returns a function that computes the mean over an array of items
@@ -8,5 +8,5 @@ export function mean<T extends object>(key: keyof T | ((d: T) => number)) {
   const keyFn =
     typeof key === 'function' ? key : (d: T) => (d[key] as unknown) as number;
 
-  return (items: T[]) => d3mean(items, keyFn);
+  return (items: T[]) => meanInternal(items, keyFn);
 }

--- a/packages/tidy/src/summary/meanRate.ts
+++ b/packages/tidy/src/summary/meanRate.ts
@@ -1,5 +1,5 @@
-import { sum as d3sum } from 'd3-array';
 import { rate } from '../math/math';
+import { sum } from '../helpers/summation';
 
 /**
  * Returns a function that computes the mean of a rate over an array of items
@@ -20,8 +20,8 @@ export function meanRate<T extends object>(
       : (d: T) => (d[denominator] as unknown) as number;
 
   return (items: T[]) => {
-    const numerator = d3sum(items, numeratorFn);
-    const denominator = d3sum(items, denominatorFn);
+    const numerator = sum(items, numeratorFn);
+    const denominator = sum(items, denominatorFn);
     return rate(numerator, denominator);
   };
 }

--- a/packages/tidy/src/summary/sum.test.ts
+++ b/packages/tidy/src/summary/sum.test.ts
@@ -1,6 +1,8 @@
 import { tidy, summarize, sum } from '../index';
+import { sum as d3sum } from 'd3-array';
 
 type MixedDatum = { str: string; value: number };
+type Datum = { value: number };
 
 describe('sum', () => {
   it('it works', () => {
@@ -21,5 +23,31 @@ describe('sum', () => {
         })
       )
     ).toEqual([{ summedValue: 15, summedValue2: 15, megaSum: 1500 }]);
+  });
+  it('corrects floating point errors', () => {
+    const data = [
+      { value: 18.7 },
+      { value: 14.3 },
+      { value: 16.4 },
+      { value: 17.3 },
+      { value: 15.2 },
+      { value: 10.4 },
+      { value: 10.4 },
+      { value: 14.7 },
+      { value: 15.5 },
+      { value: 15.2 },
+      { value: 13.3 },
+      { value: 19.2 },
+    ];
+    const result = tidy(
+      data,
+      summarize({
+        summedValue: sum<Datum>('value'),
+      })
+    )[0].summedValue;
+    const d3Result = d3sum(data.map((d) => d.value));
+    expect(result).toEqual(180.6);
+    expect(result).toBeCloseTo(d3Result);
+    expect(result).not.toEqual(d3Result);
   });
 });

--- a/packages/tidy/src/summary/sum.ts
+++ b/packages/tidy/src/summary/sum.ts
@@ -1,4 +1,4 @@
-import { sum as d3sum } from 'd3-array';
+import { sum as sumInternal } from '../helpers/summation';
 
 /**
  * Returns a function that computes the sum over an array of items
@@ -8,5 +8,5 @@ export function sum<T extends object>(key: keyof T | ((d: T) => number)) {
   const keyFn =
     typeof key === 'function' ? key : (d: T) => (d[key] as unknown) as number;
 
-  return (items: T[]) => d3sum(items, keyFn);
+  return (items: T[]) => sumInternal(items, keyFn);
 }

--- a/packages/tidy/src/vector/cumsum.test.ts
+++ b/packages/tidy/src/vector/cumsum.test.ts
@@ -1,4 +1,5 @@
-import { tidy, mutateWithSummary, cumsum } from '../index';
+import { tidy, mutateWithSummary, cumsum, pick } from '../index';
+import { cumsum as d3cumsum } from 'd3-array';
 
 describe('cumsum', () => {
   it('it works', () => {
@@ -23,5 +24,54 @@ describe('cumsum', () => {
       { str: 'bar', value: null, value2: undefined, cumsum1: 4, cumsum2: 8 },
       { str: 'bar', value: 5, value2: 4, cumsum1: 9, cumsum2: 16 },
     ]);
+  });
+  it('corrects floating point errors', () => {
+    const data = [
+      { value: 18.7 },
+      { value: 14.3 },
+      { value: 16.4 },
+      { value: 17.3 },
+      { value: 15.2 },
+      { value: 10.4 },
+      { value: 10.4 },
+      { value: 14.7 },
+      { value: 15.5 },
+      { value: 15.2 },
+      { value: 13.3 },
+      { value: 19.2 },
+    ];
+
+    const results = tidy(
+      data,
+      mutateWithSummary({
+        cumsum: cumsum('value'),
+        cumsumFn: cumsum((d) => d.value),
+        cumsumD3: (items) => d3cumsum(items.map((d) => d.value)),
+      })
+    );
+
+    expect(tidy(results, pick(['value', 'cumsum']))).toEqual([
+      { value: 18.7, cumsum: 18.7 },
+      { value: 14.3, cumsum: 33 },
+      { value: 16.4, cumsum: 49.4 },
+      { value: 17.3, cumsum: 66.7 },
+      { value: 15.2, cumsum: 81.9 },
+      { value: 10.4, cumsum: 92.3 },
+      { value: 10.4, cumsum: 102.7 },
+      { value: 14.7, cumsum: 117.4 },
+      { value: 15.5, cumsum: 132.9 },
+      { value: 15.2, cumsum: 148.1 },
+      { value: 13.3, cumsum: 161.4 },
+      { value: 19.2, cumsum: 180.6 },
+    ]);
+
+    results.forEach((item, i) => {
+      if (i < 5) {
+        expect(item.cumsum).toEqual(item.cumsumD3);
+      } else {
+        expect(item.cumsum).toBeCloseTo(item.cumsumD3);
+        expect(item.cumsum).not.toEqual(item.cumsumD3);
+      }
+    });
   });
 });

--- a/packages/tidy/src/vector/cumsum.ts
+++ b/packages/tidy/src/vector/cumsum.ts
@@ -1,4 +1,4 @@
-import { cumsum as d3cumsum } from 'd3-array';
+import { cumsum as cumsumArray } from '../helpers/summation';
 
 export function cumsum<T extends object>(
   key: keyof T | ((d: T) => number | null | undefined)
@@ -7,5 +7,5 @@ export function cumsum<T extends object>(
     typeof key === 'function' ? key : (d: T) => (d[key] as unknown) as number;
 
   // note d3cumsum returns Float64Array not a normal array
-  return (items: T[]) => d3cumsum(items, keyFn);
+  return (items: T[]) => cumsumArray(items, keyFn);
 }

--- a/website/docs/api/summary.md
+++ b/website/docs/api/summary.md
@@ -163,7 +163,7 @@ tidy(data, summarize({
 
 ## mean 
 
-Computes the mean value as per [d3-array::mean](https://github.com/d3/d3-array#mean).
+Computes the mean value as per [d3-array::mean](https://github.com/d3/d3-array#mean), using the ["improved Kahan–Babuška algorithm"](https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements) for the numerator to reduce floating point errors.
 
 ### Parameters
 
@@ -349,7 +349,7 @@ tidy(data, summarize({
 
 ## sum 
 
-Computes the sum as per [d3-array::sum](https://github.com/d3/d3-array#sum).
+Computes the sum as per [d3-array::sum](https://github.com/d3/d3-array#sum), using the ["improved Kahan–Babuška algorithm"](https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements) to reduce floating point errors.
 
 ### Parameters
 

--- a/website/docs/api/vector.md
+++ b/website/docs/api/vector.md
@@ -8,7 +8,7 @@ Mapping functions that given a collection of items produce an array of values (a
 
 ## cumsum 
 
-Returns a function that computes a cumulative sum as per [d3-array::cumsum](https://github.com/d3/d3-array#cumsum). 
+Returns a function that computes a cumulative sum as per [d3-array::cumsum](https://github.com/d3/d3-array#cumsum), using the ["improved Kahan–Babuška algorithm"](https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements) to reduce floating point errors.
 
 ### Parameters
 


### PR DESCRIPTION
I noticed that there's a floating point error in one of the [Tidy.js notebook](https://observablehq.com/@pbeshai/tidy-js-intro-demo) examples:

![image](https://user-images.githubusercontent.com/2120446/106711591-96941700-65ac-11eb-857e-a085eea162d4.png)

This switches `sum`, `cumsum`, and `mean` from the d3-array versions to the "improved Kahan-Babuška" algorithm described [here](https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements) to reduce some floating point errors.

This is probably dumb and my types are definitely dumb but if it's of interest let me know and I can also push a corresponding docs update.