### PR TITLE
refactor: switch to d3-array fsum for floating point sum

### DIFF
--- a/packages/tidy/src/helpers/summation.test.ts
+++ b/packages/tidy/src/helpers/summation.test.ts
@@ -1,49 +1,34 @@
-import { sum, cumsum, mean } from './summation';
+import { fcumsum, mean } from './summation';
 
 const data = [1, 2, 3, 4, 5];
 const badData = [NaN, null, undefined, ...data, NaN, null, undefined];
 
-describe('sum', () => {
-  it('it works with no accessor', () => {
-    expect(sum(data)).toEqual(15);
-  });
-  it('it ignores nullish', () => {
-    expect(sum(data)).toEqual(sum(badData));
-  });
-  it('it works with accessor', () => {
-    expect(sum(data, (d) => d + 1)).toEqual(20);
-    expect(sum(data, (d, i) => d + i)).toEqual(25);
-  });
-});
-
 describe('cumsum', () => {
-  it('it works with no accessor', () => {
-    expect(cumsum(data)).toEqual(Float64Array.from([1, 3, 6, 10, 15]));
-  });
-  it('it ignores nullish', () => {
-    expect(cumsum(badData)).toEqual(
-      Float64Array.from([0, 0, 0, 1, 3, 6, 10, 15, 15, 15, 15])
-    );
-  });
-  it('it works with accessor', () => {
-    expect(cumsum(data, (d) => d + 1)).toEqual(
+  it('it works', () => {
+    expect(fcumsum(data, (d) => d + 1)).toEqual(
       Float64Array.from([2, 5, 9, 14, 20])
     );
-    expect(cumsum(data, (d, i) => d + i)).toEqual(
+    expect(fcumsum(data, (d, i) => d + i)).toEqual(
       Float64Array.from([1, 4, 9, 16, 25])
+    );
+  });
+  it('it ignores nullish', () => {
+    expect(fcumsum(badData, (d) => d)).toEqual(
+      Float64Array.from([0, 0, 0, 1, 3, 6, 10, 15, 15, 15, 15])
     );
   });
 });
 
 describe('mean', () => {
-  it('it works with no accessor', () => {
-    expect(mean(data)).toEqual(3);
-  });
-  it('it ignores nullish', () => {
-    expect(mean(badData)).toEqual(3);
-  });
   it('it works with accessor', () => {
     expect(mean(data, (d) => d + 1)).toEqual(4);
     expect(mean(data, (d, i) => d + i)).toEqual(5);
+  });
+  it('it ignores nullish', () => {
+    expect(mean(badData, (d) => d)).toEqual(3);
+  });
+  it('it returns undefined for an empty array', () => {
+    expect(mean([], (d) => d)).toEqual(undefined);
+    expect(mean([null], (d) => d)).toEqual(undefined);
   });
 });

--- a/packages/tidy/src/helpers/summation.ts
+++ b/packages/tidy/src/helpers/summation.ts
@@ -8,8 +8,9 @@ export function fcumsum<T>(
   let sum = new Adder(),
     i = 0;
 
-  return Float64Array.from(items, (value) =>
-    sum.add(+accessor(value, i++, items) || 0)
+  return Float64Array.from(
+    items,
+    (value: T): number => +sum.add(+(accessor(value, i++, items) || 0))
   );
 }
 
@@ -17,10 +18,14 @@ export function mean<T>(
   items: T[],
   accessor: (element: T, i: number, array: Iterable<T>) => any
 ): number | undefined {
-  const n = items.filter((datum, i) => {
-    const value = accessor(datum, i, items);
-    return +value === value;
-  }).length;
+  let n = 0;
+  for (let i = 0; i < items.length; ++i) {
+    const value = accessor(items[i], i, items);
+    // count it if we have a valid number
+    if (+value === value) {
+      n += 1;
+    }
+  }
 
   return n ? fsum(items, accessor) / n : undefined;
 }

--- a/packages/tidy/src/helpers/summation.ts
+++ b/packages/tidy/src/helpers/summation.ts
@@ -1,112 +1,26 @@
-/**
- * These functions compute the sum, cumsum, and mean of an array with the same API as d3-array
- * instead of using a plain sum, they use the "improved Kahan-Babuška summation algorithm" to
- * correct some of the floating point error:
- * https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements
- * originally from page 40 of https://www.mat.univie.ac.at/~neum/scan/01.pdf
- */
-export function sum<T>(
+import { fsum, Adder } from 'd3-array';
+
+// See also https://observablehq.com/@fil/fcumsum
+export function fcumsum<T>(
   items: T[],
-  accessor?: (element: T, i: number, array: Iterable<T>) => any
-): number {
-  let sum: number = 0,
-    correction: number = 0,
-    temp: number = 0;
-
-  for (let i = 0; i < items.length; i++) {
-    let value: number =
-      accessor === undefined ? items[i] : accessor(items[i], i, items);
-
-    if (+value !== value) {
-      value = 0;
-    }
-
-    if (i === 0) {
-      sum = value;
-    } else {
-      temp = sum + value;
-
-      if (Math.abs(sum) >= Math.abs(value)) {
-        correction += sum - temp + value;
-      } else {
-        correction += value - temp + sum;
-      }
-
-      sum = temp;
-    }
-  }
-  return sum + correction;
-}
-
-export function cumsum<T>(
-  items: T[],
-  accessor?: (element: T, i: number, array: Iterable<T>) => any
+  accessor: (element: T, i: number, array: Iterable<T>) => any
 ): Float64Array {
-  let sum: number = 0,
-    correction: number = 0,
-    temp: number = 0,
-    cumsums: Float64Array = new Float64Array(items.length);
-  for (let i = 0; i < items.length; i++) {
-    let value: number =
-      accessor === undefined ? items[i] : accessor(items[i], i, items);
+  let sum = new Adder(),
+    i = 0;
 
-    if (+value !== value) {
-      value = 0;
-    }
-
-    if (i === 0) {
-      sum = value;
-    } else {
-      temp = sum + value;
-
-      if (Math.abs(sum) >= Math.abs(value)) {
-        correction += sum - temp + value;
-      } else {
-        correction += value - temp + sum;
-      }
-
-      sum = temp;
-    }
-
-    cumsums[i] = sum + correction;
-  }
-
-  return cumsums;
+  return Float64Array.from(items, (value) =>
+    sum.add(+accessor(value, i++, items) || 0)
+  );
 }
 
 export function mean<T>(
   items: T[],
-  accessor?: (element: T, i: number, array: Iterable<T>) => any
+  accessor: (element: T, i: number, array: Iterable<T>) => any
 ): number | undefined {
-  let n: number = 0,
-    sum: number = 0,
-    correction: number = 0,
-    temp: number = 0;
+  const n = items.filter((datum, i) => {
+    const value = accessor(datum, i, items);
+    return +value === value;
+  }).length;
 
-  for (let i = 0; i < items.length; i++) {
-    let value: number =
-      accessor === undefined ? items[i] : accessor(items[i], i, items);
-
-    if (+value !== value) {
-      value = 0;
-    } else {
-      n++;
-    }
-
-    if (i === 0) {
-      sum = value;
-    } else {
-      temp = sum + value;
-
-      if (Math.abs(sum) >= Math.abs(value)) {
-        correction += sum - temp + value;
-      } else {
-        correction += value - temp + sum;
-      }
-
-      sum = temp;
-    }
-  }
-
-  return n ? (sum + correction) / n : undefined;
+  return n ? fsum(items, accessor) / n : undefined;
 }

--- a/packages/tidy/src/summary/meanRate.ts
+++ b/packages/tidy/src/summary/meanRate.ts
@@ -1,5 +1,5 @@
+import { fsum } from 'd3-array';
 import { rate } from '../math/math';
-import { sum } from '../helpers/summation';
 
 /**
  * Returns a function that computes the mean of a rate over an array of items
@@ -20,8 +20,8 @@ export function meanRate<T extends object>(
       : (d: T) => (d[denominator] as unknown) as number;
 
   return (items: T[]) => {
-    const numerator = sum(items, numeratorFn);
-    const denominator = sum(items, denominatorFn);
+    const numerator = fsum(items, numeratorFn);
+    const denominator = fsum(items, denominatorFn);
     return rate(numerator, denominator);
   };
 }

--- a/packages/tidy/src/summary/sum.ts
+++ b/packages/tidy/src/summary/sum.ts
@@ -1,4 +1,4 @@
-import { sum as sumInternal } from '../helpers/summation';
+import { fsum } from 'd3-array';
 
 /**
  * Returns a function that computes the sum over an array of items
@@ -8,5 +8,5 @@ export function sum<T extends object>(key: keyof T | ((d: T) => number)) {
   const keyFn =
     typeof key === 'function' ? key : (d: T) => (d[key] as unknown) as number;
 
-  return (items: T[]) => sumInternal(items, keyFn);
+  return (items: T[]) => fsum(items, keyFn);
 }

--- a/packages/tidy/src/vector/cumsum.ts
+++ b/packages/tidy/src/vector/cumsum.ts
@@ -1,4 +1,4 @@
-import { cumsum as cumsumArray } from '../helpers/summation';
+import { fcumsum } from '../helpers/summation';
 
 export function cumsum<T extends object>(
   key: keyof T | ((d: T) => number | null | undefined)
@@ -6,6 +6,6 @@ export function cumsum<T extends object>(
   const keyFn =
     typeof key === 'function' ? key : (d: T) => (d[key] as unknown) as number;
 
-  // note d3cumsum returns Float64Array not a normal array
-  return (items: T[]) => cumsumArray(items, keyFn);
+  // note returns Float64Array not a normal array
+  return (items: T[]) => fcumsum(items, keyFn);
 }

--- a/website/docs/api/summary.md
+++ b/website/docs/api/summary.md
@@ -163,7 +163,7 @@ tidy(data, summarize({
 
 ## mean 
 
-Computes the mean value as per [d3-array::mean](https://github.com/d3/d3-array#mean), using the ["improved Kahan–Babuška algorithm"](https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements) for the numerator to reduce floating point errors.
+Computes the mean value as per [d3-array::mean](https://github.com/d3/d3-array#mean), using [d3-array::fsum](https://github.com/d3/d3-array#fsum) to reduce floating point errors.
 
 ### Parameters
 
@@ -349,7 +349,7 @@ tidy(data, summarize({
 
 ## sum 
 
-Computes the sum as per [d3-array::sum](https://github.com/d3/d3-array#sum), using the ["improved Kahan–Babuška algorithm"](https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements) to reduce floating point errors.
+Computes the sum as per [d3-array::fsum](https://github.com/d3/d3-array#fsum).
 
 ### Parameters
 

--- a/website/docs/api/vector.md
+++ b/website/docs/api/vector.md
@@ -8,7 +8,7 @@ Mapping functions that given a collection of items produce an array of values (a
 
 ## cumsum 
 
-Returns a function that computes a cumulative sum as per [d3-array::cumsum](https://github.com/d3/d3-array#cumsum), using the ["improved Kahan–Babuška algorithm"](https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements) to reduce floating point errors.
+Returns a function that computes a cumulative sum as per [d3-array::cumsum](https://github.com/d3/d3-array#cumsum), using [d3-array::fsum](https://github.com/d3/d3-array#fsum) to reduce floating point errors.
 
 ### Parameters
 


### PR DESCRIPTION
Switches from manual implementation of a floating point sum algo to [d3 fsum](https://github.com/d3/d3-array#fsum) - thanks @fil!

Also, since this is only used internally, accessor will always be defined, so not bothering to handle the other case.