### PR TITLE
fix: treat sort comparisons that aren't <,>,or == as 0

### DIFF
--- a/packages/tidy/src/arrange.test.ts
+++ b/packages/tidy/src/arrange.test.ts
@@ -44,6 +44,46 @@ describe('arrange', () => {
     ]);
   });
 
+  it('treats NaN comparisons as 0', () => {
+    const results = tidy(
+      [
+        { str: 'foo', value: 3 },
+        { str: 'foo', value: 1 },
+        { str: 'bar', value: 3 },
+        { str: 'bar', value: 1 },
+        { str: 'bar', value: 7 },
+      ],
+      arrange(['doesntexist', 'str', 'value'])
+    );
+
+    expect(results).toEqual([
+      { str: 'bar', value: 1 },
+      { str: 'bar', value: 3 },
+      { str: 'bar', value: 7 },
+      { str: 'foo', value: 1 },
+      { str: 'foo', value: 3 },
+    ]);
+
+    expect(
+      tidy(
+        [
+          { str: 'foo', value: 3 },
+          { str: 'foo', value: 1 },
+          { str: 'bar', value: 3 },
+          { str: 'bar', value: 1 },
+          { str: 'bar', value: 7 },
+        ],
+        arrange(['str', desc('doesntexist'), asc('value')])
+      )
+    ).toEqual([
+      { str: 'bar', value: 1 },
+      { str: 'bar', value: 3 },
+      { str: 'bar', value: 7 },
+      { str: 'foo', value: 1 },
+      { str: 'foo', value: 3 },
+    ]);
+  });
+
   it('arranges with multiple keys desc', () => {
     expect(
       tidy(

--- a/packages/tidy/src/arrange.test.ts
+++ b/packages/tidy/src/arrange.test.ts
@@ -1,8 +1,6 @@
 import { tidy, arrange, asc, desc, fixedOrder } from './index';
 import { ascending } from 'd3-array';
 
-type MixedDatum = { str: string; value: number };
-
 describe('arrange', () => {
   it('arranges with multiple keys asc', () => {
     const results = tidy(
@@ -81,6 +79,37 @@ describe('arrange', () => {
       { str: 'bar', value: 7 },
       { str: 'foo', value: 1 },
       { str: 'foo', value: 3 },
+    ]);
+
+    expect(
+      tidy(
+        [
+          { str: 'foo', value: null },
+          { str: 'foo', value: NaN },
+          { str: 'foo', value: 9 },
+          { str: 'foo', value: 1 },
+          { str: 'foo', value: '' },
+          { str: 'foo', value: undefined },
+          { str: 'foo', value: null, o: 1 },
+          { str: 'bar', value: 3 },
+          { str: 'bar', value: null },
+          { str: 'bar', value: 7 },
+          { str: 'bar', value: 2 },
+        ],
+        arrange(['str', desc('doesntexist'), asc('value')])
+      )
+    ).toEqual([
+      { str: 'bar', value: 2 },
+      { str: 'bar', value: 3 },
+      { str: 'bar', value: 7 },
+      { str: 'bar', value: null },
+      { str: 'foo', value: '' },
+      { str: 'foo', value: 1 },
+      { str: 'foo', value: 9 },
+      { str: 'foo', value: NaN },
+      { str: 'foo', value: null },
+      { str: 'foo', value: null, o: 1 },
+      { str: 'foo', value: undefined },
     ]);
   });
 

--- a/packages/tidy/src/arrange.ts
+++ b/packages/tidy/src/arrange.ts
@@ -18,7 +18,7 @@ export function arrange<T extends object>(
     return items.slice().sort((a, b) => {
       for (const comparator of comparatorFns) {
         const result = comparator(a, b);
-        if (result !== 0) return result;
+        if (result) return result;
       }
 
       return 0;


### PR DESCRIPTION
`arrange()` uses `d3.ascending` and `d3.descending` to apply each comparator in a sequence.

`d3.ascending` returns NaN in cases like:

```
d3.ascending(undefined, undefined)
d3.ascending("x", 5)
d3.ascending(NaN, NaN)
```

This means that in a flow like:

```
tidy(data, arrange(["nonexistentkey", "population"]));
```

it will leave the data in its original order instead of sorting by population because any non-zero, including NaN, stops the comparison chain.

It seems like the expected behavior would be to continue past those comparisons and apply whatever's next in the chain.