### PR TITLE
Allow `second` and `minute` granularity

### DIFF
--- a/packages/tidy-moment/src/summarizeMomentGranularity.ts
+++ b/packages/tidy-moment/src/summarizeMomentGranularity.ts
@@ -56,12 +56,12 @@ export function summarizeMomentGranularity<
     } = options;
 
     const dateFormats = {
-      s: 'YYYY-MM-DDThh-mm-ss',
-      seconds: 'YYYY-MM-DDThh-mm-ss',
-      second: 'YYYY-MM-DDThh-mm-ss',
-      min: 'YYYY-MM-DDThh-mm',
-      minutes: 'YYYY-MMTDD-hh-mm',
-      minute: 'YYYY-MMTDD-hh-mm',
+      s: 'YYYY-MM-DDTHH:mm:ss',
+      seconds: 'YYYY-MM-DDTHH:mm:ss',
+      second: 'YYYY-MM-DDTHH:mm:ss',
+      min: 'YYYY-MM-DDTHH:mm',
+      minutes: 'YYYY-MMDDTHH:mm',
+      minute: 'YYYY-MM-DDTHH:mm',
       d: 'YYYY-MM-DD',
       days: 'YYYY-MM-DD',
       day: 'YYYY-MM-DD',

--- a/packages/tidy-moment/src/summarizeMomentGranularity.ts
+++ b/packages/tidy-moment/src/summarizeMomentGranularity.ts
@@ -56,6 +56,12 @@ export function summarizeMomentGranularity<
     } = options;
 
     const dateFormats = {
+      s: 'YYYY-MM-DDThh-mm-ss',
+      seconds: 'YYYY-MM-DDThh-mm-ss',
+      second: 'YYYY-MM-DDThh-mm-ss',
+      min: 'YYYY-MM-DDThh-mm',
+      minutes: 'YYYY-MMTDD-hh-mm',
+      minute: 'YYYY-MMTDD-hh-mm',
       d: 'YYYY-MM-DD',
       days: 'YYYY-MM-DD',
       day: 'YYYY-MM-DD',

--- a/packages/tidy/src/sequences/fullSeq.test.ts
+++ b/packages/tidy/src/sequences/fullSeq.test.ts
@@ -35,6 +35,37 @@ describe('fullSeqDate', () => {
   });
 });
 
+describe('fullSeqDate', () => {
+  it('seconds granularity works', () => {
+    const data = [
+      { str: 'foo', date: new Date('2077-01-01T00:00:00.000Z') },
+      { str: 'foo', date: new Date('2077-01-01T00:00:04.000Z') },
+    ];
+    expect(fullSeqDate('date', 'second', 2)(data)).toEqual([
+      new Date('2077-01-01T00:00:00.000Z'),
+      new Date('2077-01-01T00:00:02.000Z'),
+      new Date('2077-01-01T00:00:04.000Z'),
+    ]);
+  });
+});
+
+describe('fullSeqDate', () => {
+  it('minute granularity works', () => {
+    const data = [
+      { str: 'foo', date: new Date('2077-01-01T00:01:00.000Z') },
+      { str: 'foo', date: new Date('2077-01-01T00:05:00.000Z') },
+      { str: 'foo', date: new Date('2077-01-01T00:03:00.000Z') },
+    ];
+    expect(fullSeqDate('date', 'minute', 1)(data)).toEqual([
+      new Date('2077-01-01T00:01:00.000Z'),
+      new Date('2077-01-01T00:02:00.000Z'),
+      new Date('2077-01-01T00:03:00.000Z'),
+      new Date('2077-01-01T00:04:00.000Z'),
+      new Date('2077-01-01T00:05:00.000Z'),
+    ]);
+  });
+});
+
 describe('fullSeqDateISOString', () => {
   it('it works', () => {
     const data = [

--- a/packages/tidy/src/sequences/fullSeq.ts
+++ b/packages/tidy/src/sequences/fullSeq.ts
@@ -33,17 +33,41 @@ export function vectorSeqDate(
     sequence.push(new Date(value));
 
     // increment date
-    if (['second', 's', 'seconds'].includes(granularity)) {
+    if (
+      granularity === 'second' ||
+      granularity === 's' ||
+      granularity === 'seconds'
+    ) {
       value.setUTCSeconds(value.getUTCSeconds() + 1 * period);
-    } else if (['minute', 'min', 'minutes'].includes(granularity)) {
+    } else if (
+      granularity === 'minute' ||
+      granularity === 'min' ||
+      granularity === 'minutes'
+    ) {
       value.setUTCMinutes(value.getUTCMinutes() + 1 * period);
-    } else if (['day', 'd', 'days'].includes(granularity)) {
+    } else if (
+      granularity === 'day' ||
+      granularity === 'd' ||
+      granularity === 'days'
+    ) {
       value.setUTCDate(value.getUTCDate() + 1 * period);
-    } else if (['week', 'w', 'weeks'].includes(granularity)) {
+    } else if (
+      granularity === 'week' ||
+      granularity === 'w' ||
+      granularity === 'weeks'
+    ) {
       value.setUTCDate(value.getUTCDate() + 7 * period);
-    } else if (['month', 'm', 'months'].includes(granularity)) {
+    } else if (
+      granularity === 'month' ||
+      granularity === 'm' ||
+      granularity === 'months'
+    ) {
       value.setUTCMonth(value.getUTCMonth() + 1 * period);
-    } else if (['year', 'y', 'years'].includes(granularity)) {
+    } else if (
+      granularity === 'year' ||
+      granularity === 'y' ||
+      granularity === 'years'
+    ) {
       value.setUTCFullYear(value.getUTCFullYear() + 1 * period);
     } else {
       throw new Error('Invalid granularity for date sequence: ' + granularity);

--- a/packages/tidy/src/sequences/fullSeq.ts
+++ b/packages/tidy/src/sequences/fullSeq.ts
@@ -33,29 +33,17 @@ export function vectorSeqDate(
     sequence.push(new Date(value));
 
     // increment date
-    if (
-      granularity === 'day' ||
-      granularity === 'd' ||
-      granularity === 'days'
-    ) {
+    if (['second', 's', 'seconds'].includes(granularity)) {
+      value.setUTCSeconds(value.getUTCSeconds() + 1 * period);
+    } else if (['minute', 'min', 'minutes'].includes(granularity)) {
+      value.setUTCMinutes(value.getUTCMinutes() + 1 * period);
+    } else if (['day', 'd', 'days'].includes(granularity)) {
       value.setUTCDate(value.getUTCDate() + 1 * period);
-    } else if (
-      granularity === 'week' ||
-      granularity === 'w' ||
-      granularity === 'weeks'
-    ) {
+    } else if (['week', 'w', 'weeks'].includes(granularity)) {
       value.setUTCDate(value.getUTCDate() + 7 * period);
-    } else if (
-      granularity === 'month' ||
-      granularity === 'm' ||
-      granularity === 'months'
-    ) {
+    } else if (['month', 'm', 'months'].includes(granularity)) {
       value.setUTCMonth(value.getUTCMonth() + 1 * period);
-    } else if (
-      granularity === 'year' ||
-      granularity === 'y' ||
-      granularity === 'years'
-    ) {
+    } else if (['year', 'y', 'years'].includes(granularity)) {
       value.setUTCFullYear(value.getUTCFullYear() + 1 * period);
     } else {
       throw new Error('Invalid granularity for date sequence: ' + granularity);

--- a/packages/tidy/src/types.ts
+++ b/packages/tidy/src/types.ts
@@ -40,6 +40,12 @@ export type TidyGroupExportFn<InputT extends object, ExportedT> = (
 ) => ExportedT;
 
 export type Granularity =
+  | 's'
+  | 'seconds'
+  | 'second'
+  | 'min'
+  | 'minutes'
+  | 'minute'
   | 'd'
   | 'days'
   | 'day' // for backwards compatibility

--- a/website/docs/api/sequences.md
+++ b/website/docs/api/sequences.md
@@ -12,12 +12,11 @@ Creates a full sequence of number values for a key given a set of data. The boun
 #### `key`
 
 ```ts
-| string 
+| string
 | (item: object) => number
 ```
 
 The key within the data to expand the sequence across.
-
 
 #### `period`
 
@@ -26,7 +25,6 @@ number = 1
 ```
 
 The gap between each value in the data (how much the sequence increments by).
-
 
 ### Usage
 
@@ -57,21 +55,19 @@ Similar to [**fullSeq**](#fullseq).
 #### `key`
 
 ```ts
-| string 
+| string
 | (item: object) => Date
 ```
 
 The key within the data to expand the sequence across.
 
-
 #### `granularity`
 
 ```ts
-'day' | 'week' | 'month' | 'year' = 'day'
+'second' | 'minute' | 'day' | 'week' | 'month' | 'year' = 'day'
 ```
 
 The granularity to increment the data by.
-
 
 #### `period`
 
@@ -80,7 +76,6 @@ number = 1
 ```
 
 The gap between each value in the data (how much the sequence increments by).
-
 
 ### Usage
 
@@ -126,15 +121,13 @@ Similar to [**fullSeq**](#fullseq).
 
 The key within the data to expand the sequence across.
 
-
 #### `granularity`
 
 ```ts
-'day' | 'week' | 'month' | 'year' = 'day'
+'second' | 'minute' | 'day' | 'week' | 'month' | 'year' = 'day'
 ```
 
 The granularity to increment the data by.
-
 
 #### `period`
 
@@ -143,7 +136,6 @@ number = 1
 ```
 
 The gap between each value in the data (how much the sequence increments by).
-
 
 ### Usage
 


### PR DESCRIPTION
Hey there Peter,

I use Tidy.js for mocking data in Storybook and also to test some React components.

At the moment I am building a monitoring platform for Neo4j databases, and a more frequent granularity was useful for me to check how charts are displaying in the time axis, and mock more appropriate data suited for my use case. 

I am not sure if granularity of `day` with a period of `1 / (24(h)*60(minutes))` would work, to update the granularity with a period of one minute, but a more native implementation helped me, so I though of making a PR.