### PR TITLE
feat: add in nDistinct summarizer

### DIFF
--- a/packages/tidy/src/index.ts
+++ b/packages/tidy/src/index.ts
@@ -73,6 +73,7 @@ export { median } from './summary/median';
 export { deviation } from './summary/deviation';
 export { variance } from './summary/variance';
 export { n } from './summary/n';
+export { nDistinct } from './summary/nDistinct';
 export { first } from './summary/first';
 export { last } from './summary/last';
 

--- a/packages/tidy/src/summary/nDistinct.test.ts
+++ b/packages/tidy/src/summary/nDistinct.test.ts
@@ -1,0 +1,123 @@
+import { tidy, mutateWithSummary, summarize, nDistinct } from '../index';
+
+describe('nDistinct', () => {
+  it('it works', () => {
+    const data = [
+      { str: 'foo', value: 3 },
+      { str: 'foo', value: 1 },
+      { str: 'bar', value: 3 },
+      { str: 'bar', value: 1 },
+      { str: 'bar', value: 7 },
+      { str: 'bar', value: 1 },
+    ];
+
+    expect(
+      tidy(
+        data,
+        summarize({
+          numStr: nDistinct('str'),
+          numValue: nDistinct((d) => d.value),
+          numDistinct: nDistinct((d) => `${d.str}_${d.value}`),
+          numNone: nDistinct('foo' as any),
+        })
+      )
+    ).toEqual([{ numStr: 2, numValue: 3, numDistinct: 5, numNone: 0 }]);
+
+    expect(
+      tidy(
+        data,
+        mutateWithSummary({
+          numStr: nDistinct('str'),
+        })
+      )
+    ).toEqual([
+      { str: 'foo', value: 3, numStr: 2 },
+      { str: 'foo', value: 1, numStr: 2 },
+      { str: 'bar', value: 3, numStr: 2 },
+      { str: 'bar', value: 1, numStr: 2 },
+      { str: 'bar', value: 7, numStr: 2 },
+      { str: 'bar', value: 1, numStr: 2 },
+    ]);
+
+    expect(tidy([], summarize({ n: nDistinct('foo') }))).toEqual([{ n: 0 }]);
+
+    expect(
+      tidy(
+        [
+          { foo: null, bar: undefined },
+          { foo: 1, bar: 'a' },
+          { foo: 1, bar: null },
+          { foo: 2, bar: 'b' },
+          { foo: null, bar: 'b' },
+        ],
+        summarize({
+          numFooBoth: nDistinct('foo', {
+            includeNull: true,
+            includeUndefined: true,
+          }),
+          numFooNull: nDistinct('foo', {
+            includeNull: true,
+            includeUndefined: false,
+          }),
+          numFooUndef: nDistinct('foo', {
+            includeNull: false,
+            includeUndefined: true,
+          }),
+          numFooNone: nDistinct('foo', {
+            includeNull: false,
+            includeUndefined: false,
+          }),
+
+          numBarBoth: nDistinct('bar', {
+            includeNull: true,
+            includeUndefined: true,
+          }),
+          numBarNull: nDistinct('bar', {
+            includeNull: true,
+            includeUndefined: false,
+          }),
+          numBarUndef: nDistinct('bar', {
+            includeNull: false,
+            includeUndefined: true,
+          }),
+          numBarNone: nDistinct('bar', {
+            includeNull: false,
+            includeUndefined: false,
+          }),
+
+          numBazBoth: nDistinct('baz' as any, {
+            includeNull: true,
+            includeUndefined: true,
+          }),
+          numBazNull: nDistinct('baz' as any, {
+            includeNull: true,
+            includeUndefined: false,
+          }),
+          numBazUndef: nDistinct('baz' as any, {
+            includeNull: false,
+            includeUndefined: true,
+          }),
+          numBazNone: nDistinct('baz' as any, {
+            includeNull: false,
+            includeUndefined: false,
+          }),
+        })
+      )
+    ).toEqual([
+      {
+        numFooBoth: 3,
+        numFooNull: 3,
+        numFooUndef: 2,
+        numFooNone: 2,
+        numBarBoth: 4,
+        numBarNull: 3,
+        numBarUndef: 3,
+        numBarNone: 2,
+        numBazBoth: 1,
+        numBazNull: 0,
+        numBazUndef: 1,
+        numBazNone: 0,
+      },
+    ]);
+  });
+});

--- a/packages/tidy/src/summary/nDistinct.ts
+++ b/packages/tidy/src/summary/nDistinct.ts
@@ -1,0 +1,34 @@
+/**
+ * Returns a function that computes the distinct count for a key
+ * over an array of items. By default it counts nulls but not undefined
+ */
+export function nDistinct<T extends object>(
+  key: keyof T | ((d: T) => any),
+  options: { includeNull?: boolean; includeUndefined?: boolean } = {}
+) {
+  const keyFn = typeof key === 'function' ? key : (d: T) => d[key];
+
+  return (items: T[]) => {
+    const uniques = new Map();
+    let count = 0;
+
+    for (const item of items) {
+      const value = keyFn(item);
+
+      if (!uniques.has(value)) {
+        // default includes null but not undefined
+        if (
+          (!options.includeUndefined && value === undefined) ||
+          (options.includeNull === false && value === null)
+        ) {
+          continue;
+        }
+
+        count += 1;
+        uniques.set(value, true);
+      }
+    }
+
+    return count;
+  };
+}

--- a/website/docs/api/summary.md
+++ b/website/docs/api/summary.md
@@ -343,6 +343,72 @@ tidy(data, summarize({
 ```
 
 
+
+---
+
+
+
+## nDistinct
+
+Computes the number of distinct values for a key in the collection.
+
+### Parameters
+
+#### `key`
+
+```ts
+| string /* key of object */
+| (item: object) => any
+```
+
+The key or function to compute the distinct values over.
+
+
+#### `options`
+
+```ts
+{ 
+  includeNull?: boolean = true
+  includeUndefined?: boolean = false
+}
+```
+
+* `includeNull = true` whether or not to count `null` as a distinct value
+* `includeUndefined = false` whether or not to count `undefined` as a distinct value
+
+
+### Usage
+
+```js
+const data = [
+  { str: 'foo', value: 3 },
+  { str: 'foo', value: 1 },
+  { str: 'bar', value: 3 },
+  { str: 'bar', value: 1 },
+  { str: 'bar', value: 7 },
+  { str: 'bar', value: undefined },
+];
+
+tidy(data, summarize({
+  numStr: nDistinct('str'),
+})
+// output:
+[{ numStr: 2 }]
+
+tidy(data, summarize({
+  numValue: nDistinct(d => d.value),
+})
+// output:
+[{ numValue: 3 }]
+
+tidy(data, summarize({
+  numValue: nDistinct(d => d.value, { includeUndefined: true }),
+})
+// output:
+[{ numValue: 4 }]
+```
+
+
 ---
 
 

--- a/website/docs/api/tidy.md
+++ b/website/docs/api/tidy.md
@@ -113,7 +113,7 @@ Sorts items by the specified keys and comparators.
 
 A key or set of keys of the item to sort by, or comparator functions that return -1, 0, or 1 if a < b, a == b, a > b respectively. You can mix and match keys and comparator functions when supplying an array.
 
-For convenience, you can flip to descending order for keys by wrapping the key string with the `desc(key: string)` function.
+For convenience, you can flip to descending order for keys by wrapping the key string with the `desc(key: string)` function. There is a corresponding `asc(key: string)` function for ascending data, but this is the default, so is unnecessary to use.
 
 You can also sort the values for a key in a pre-specified order with the fixedOrder function:
 

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -111,6 +111,7 @@ const functions = [
       'median',
       'min',
       'n',
+      'nDistinct',
       'sum',
       'variance',
     ],


### PR DESCRIPTION
* Adds in the `nDistinct` summarizer, similar to https://dplyr.tidyverse.org/reference/n_distinct.html, for counting the number of distinct values for a specified key.