### PR TITLE
Use standard arrange behavior in sliceMax

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+packages/tidy/src/tidy.ts

--- a/packages/tidy/.prettierignore
+++ b/packages/tidy/.prettierignore
@@ -1,1 +1,0 @@
-src/tidy.ts

--- a/packages/tidy/src/slice.test.ts
+++ b/packages/tidy/src/slice.test.ts
@@ -51,6 +51,7 @@ describe('slice', () => {
       { value: 3 },
       { value: 1 },
       { value: 4 },
+      { value: null },
       { value: 5 },
       { value: 2 },
     ];
@@ -63,6 +64,7 @@ describe('slice', () => {
       { value: 3 },
       { value: 1 },
       { value: 4 },
+      { value: null },
       { value: 5 },
       { value: 2 },
     ];

--- a/packages/tidy/src/slice.ts
+++ b/packages/tidy/src/slice.ts
@@ -1,5 +1,5 @@
 import { shuffle } from 'd3-array';
-import { arrange } from './arrange';
+import { arrange, desc } from './arrange';
 import { SingleOrArray } from './helpers/singleOrArray';
 import { Comparator, Key, TidyFn } from './types';
 
@@ -51,8 +51,12 @@ export function sliceMax<T extends object>(
   n: number,
   orderBy: SingleOrArray<Key | Comparator<T>>
 ): TidyFn<T> {
+  // note: we use desc() so we get proper handling of nullish values
+  // unless they provided an explicit comparator.
   const _sliceMax: TidyFn<T> = (items: T[]): T[] =>
-    arrange<T>(orderBy)(items).slice(-n).reverse();
+    typeof orderBy === 'function'
+      ? arrange<T>(orderBy)(items).slice(-n).reverse()
+      : arrange<T>(desc(orderBy as any))(items).slice(0, n);
 
   return _sliceMax;
 }

--- a/packages/tidy/src/tidy.ts
+++ b/packages/tidy/src/tidy.ts
@@ -39,7 +39,10 @@ export function tidy<InputT extends object>(
 
   let result: any = items;
   for (const fn of fns) {
-    result = fn(result);
+    if (fn) {
+      // skip falsy values
+      result = fn(result);
+    }
   }
 
   return result;


### PR DESCRIPTION
* fix bug where nulls would be returned from sliceMax since we didn't use desc()
* fix bug where tidy flows failed if falsy values were passed