### PR TITLE
feat: allow accessors to work with asc desc

### DIFF
--- a/packages/tidy/src/arrange.test.ts
+++ b/packages/tidy/src/arrange.test.ts
@@ -320,4 +320,43 @@ describe('arrange', () => {
       ['A', 'B', 'C'].sort(fixedOrder((d) => d, ['C', 'A', 'B']))
     ).toEqual(['C', 'A', 'B']);
   });
+
+  it('works with function accessors passed to asc or desc', () => {
+    const results = tidy(
+      [
+        { str: 'foo', value: 3 },
+        { str: 'foo', value: 1 },
+        { str: 'bar', value: 3 },
+        { str: 'bar', value: 1 },
+        { str: 'bar', value: 7 },
+      ],
+      arrange([asc((d) => d.str), desc((d) => d.value)])
+    );
+    expect(results).toEqual([
+      { str: 'bar', value: 7 },
+      { str: 'bar', value: 3 },
+      { str: 'bar', value: 1 },
+      { str: 'foo', value: 3 },
+      { str: 'foo', value: 1 },
+    ]);
+
+    expect(arrange(asc((d) => d))([5, 0, null, 1, 3, -2, 0] as any)).toEqual([
+      -2,
+      0,
+      0,
+      1,
+      3,
+      5,
+      null,
+    ]);
+    expect(arrange(desc((d) => d))([5, 0, null, 1, 3, -2, 0] as any)).toEqual([
+      5,
+      3,
+      1,
+      0,
+      0,
+      -2,
+      null,
+    ]);
+  });
 });

--- a/packages/tidy/src/arrange.ts
+++ b/packages/tidy/src/arrange.ts
@@ -1,6 +1,6 @@
 import { ascending } from 'd3-array';
 import { SingleOrArray, singleOrArray } from './helpers/singleOrArray';
-import { Comparator, Key, KeyOrFn, Primitive, TidyFn } from './types';
+import { Comparator, Key, KeyOrFn, TidyFn } from './types';
 
 /**
  * Sorts items
@@ -32,13 +32,11 @@ export function arrange<T extends object>(
  * Creates an ascending comparator based on a key
  * @param key property key of T
  */
-export function asc<T>(key: Key): Comparator<T> {
+export function asc<T>(key: Key | ((d: T) => any)): Comparator<T> {
+  const keyFn = typeof key === 'function' ? key : (d: any) => d[key];
+
   return function _asc(a: T, b: T) {
-    return emptyAwareComparator(
-      (a[key as keyof T] as unknown) as Primitive,
-      (b[key as keyof T] as unknown) as Primitive,
-      false
-    );
+    return emptyAwareComparator(keyFn(a), keyFn(b), false);
   };
 }
 
@@ -46,13 +44,10 @@ export function asc<T>(key: Key): Comparator<T> {
  * Creates a descending comparator based on a key
  * @param key property key of T
  */
-export function desc<T>(key: Key): Comparator<T> {
+export function desc<T>(key: Key | ((d: T) => any)): Comparator<T> {
+  const keyFn = typeof key === 'function' ? key : (d: any) => d[key];
   return function _desc(a: T, b: T) {
-    return emptyAwareComparator(
-      (a[key as keyof T] as unknown) as Primitive,
-      (b[key as keyof T] as unknown) as Primitive,
-      true
-    );
+    return emptyAwareComparator(keyFn(a), keyFn(b), true);
   };
 }
 


### PR DESCRIPTION
* makes it so you can pass an accessor to `asc()` or `desc()` when using arrange. Previously you would have to use your own comparator and would miss out on the cool empty aware comparator we use.
