### PR TITLE
feat: support groupBy no fns, single fn

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "rollup": "^2.36.1",
     "rollup-plugin-esbuild": "^2.6.1",
     "ts-jest": "^26.4.4",
-    "typescript": "^4.1.3"
+    "typescript": "^4.2.4"
   },
   "workspaces": {
     "packages": [

--- a/packages/tidy/src/groupBy.test.ts
+++ b/packages/tidy/src/groupBy.test.ts
@@ -385,6 +385,78 @@ describe('groupBy / ungroup', () => {
       );
       expect(results3).toEqual(results2);
     });
+
+    it('works with flexible arguments', () => {
+      const data = [
+        { str: 'a', ing: 'x', foo: 'G', value: 1 },
+        { str: 'b', ing: 'x', foo: 'H', value: 100 },
+        { str: 'b', ing: 'x', foo: 'K', value: 200 },
+        { str: 'a', ing: 'y', foo: 'G', value: 2 },
+        { str: 'a', ing: 'z', foo: 'K', value: 5 },
+        { str: 'a', ing: 'y', foo: 'H', value: 3 },
+        { str: 'a', ing: 'y', foo: 'K', value: 4 },
+        { str: 'b', ing: 'y', foo: 'G', value: 300 },
+        { str: 'b', ing: 'z', foo: 'H', value: 400 },
+        { str: 'a', ing: 'z', foo: 'G', value: 6 },
+      ];
+
+      const results = tidy(data, groupBy('str'));
+
+      expect(results).toEqual([
+        { str: 'a', ing: 'x', foo: 'G', value: 1 },
+        { str: 'a', ing: 'y', foo: 'G', value: 2 },
+        { str: 'a', ing: 'z', foo: 'K', value: 5 },
+        { str: 'a', ing: 'y', foo: 'H', value: 3 },
+        { str: 'a', ing: 'y', foo: 'K', value: 4 },
+        { str: 'a', ing: 'z', foo: 'G', value: 6 },
+        { str: 'b', ing: 'x', foo: 'H', value: 100 },
+        { str: 'b', ing: 'x', foo: 'K', value: 200 },
+        { str: 'b', ing: 'y', foo: 'G', value: 300 },
+        { str: 'b', ing: 'z', foo: 'H', value: 400 },
+      ]);
+
+      const results2 = tidy(data, groupBy('str', groupBy.entries()));
+      expect(results2).toEqual([
+        [
+          'a',
+          [
+            { str: 'a', ing: 'x', foo: 'G', value: 1 },
+            { str: 'a', ing: 'y', foo: 'G', value: 2 },
+            { str: 'a', ing: 'z', foo: 'K', value: 5 },
+            { str: 'a', ing: 'y', foo: 'H', value: 3 },
+            { str: 'a', ing: 'y', foo: 'K', value: 4 },
+            { str: 'a', ing: 'z', foo: 'G', value: 6 },
+          ],
+        ],
+        [
+          'b',
+          [
+            { str: 'b', ing: 'x', foo: 'H', value: 100 },
+            { str: 'b', ing: 'x', foo: 'K', value: 200 },
+            { str: 'b', ing: 'y', foo: 'G', value: 300 },
+            { str: 'b', ing: 'z', foo: 'H', value: 400 },
+          ],
+        ],
+      ]);
+
+      const results3 = tidy(
+        data,
+        groupBy('str', summarize({ total: sum('value') }), groupBy.entries())
+      );
+      expect(results3).toEqual([
+        ['a', [{ str: 'a', total: 21 }]],
+        ['b', [{ str: 'b', total: 1000 }]],
+      ]);
+
+      const results4 = tidy(
+        data,
+        groupBy('str', summarize({ total: sum('value') }))
+      );
+      expect(results4).toEqual([
+        { str: 'a', total: 21 },
+        { str: 'b', total: 1000 },
+      ]);
+    });
   });
 
   describe('exports', () => {

--- a/packages/tidy/src/groupBy.ts
+++ b/packages/tidy/src/groupBy.ts
@@ -161,6 +161,8 @@ type GroupByFn<
  * Nests the data by the specified groupings
  */
 // prettier-ignore
+export function groupBy<T extends object, T1 extends object, Keys extends GK<T>, Opts extends GroupByOptions>(groupKeys: Keys, fns: F<T, T1>, options?: Opts): GroupByFn<T, T1, Keys, Opts>;
+// prettier-ignore
 export function groupBy<T extends object, T1 extends object, T2 extends object, T3 extends object, T4 extends object, T5 extends object, T6 extends object, T7 extends object, Keys extends GK<T>, Opts extends GroupByOptions>(groupKeys: Keys, fns: [F<T, T1>, F<T1, T2>, F<T2, T3>, F<T3, T4>, F<T4, T5>, F<T5, T6>, F<T6, T7>], options?: Opts): GroupByFn<T, T7, Keys, Opts>;
 // prettier-ignore
 export function groupBy<T extends object, T1 extends object, T2 extends object, T3 extends object, T4 extends object, T5 extends object, T6 extends object, Keys extends GK<T>, Opts extends GroupByOptions>(groupKeys: Keys, fns: [F<T, T1>, F<T1, T2>, F<T2, T3>, F<T3, T4>, F<T4, T5>, F<T5, T6>], options?: Opts): GroupByFn<T, T6, Keys, Opts>;
@@ -176,6 +178,8 @@ export function groupBy<T extends object, T1 extends object, T2 extends object, 
 export function groupBy<T extends object, T1 extends object, Keys extends GK<T>, Opts extends GroupByOptions>(groupKeys: Keys, fns: [F<T, T1>], options?: Opts): GroupByFn<T, T1, Keys, Opts>;
 // prettier-ignore
 export function groupBy<T extends object, Keys extends GK<T>, Opts extends GroupByOptions>(groupKeys: Keys, fns: [], options?: Opts): GroupByFn<T, T, Keys, Opts>;
+// prettier-ignore
+export function groupBy<T extends object, Keys extends GK<T>, Opts extends GroupByOptions>(groupKeys: Keys, options?: Opts): GroupByFn<T, T, Keys, Opts>;
 export function groupBy<
   T extends object,
   O extends object,
@@ -183,15 +187,25 @@ export function groupBy<
   Opts extends GroupByOptions
 >(
   groupKeys: Keys,
-  fns: TidyFn<any, any>[],
+  fns: TidyFn<any, any>[] | TidyFn<any, any>,
   options?: Opts
 ): GroupByFn<T, O, Keys, Opts> {
+  if (typeof fns === 'function') {
+    fns = [fns];
+  } else if (arguments.length === 2 && fns != null && !Array.isArray(fns)) {
+    options = fns as any;
+  }
+
   const _groupBy: GroupByFn<T, O, Keys, Opts> = ((items: T[]) => {
     // form into a nested map
     const grouped = makeGrouped(items, groupKeys);
 
     // run group functions
-    const results = runFlow(grouped, fns, options?.addGroupKeys);
+    const results = runFlow(
+      grouped,
+      fns as TidyFn<any, any>[],
+      options?.addGroupKeys
+    );
 
     // export
     if (options?.export) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15458,10 +15458,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 ua-parser-js@^0.7.18:
   version "0.7.23"


### PR DESCRIPTION
* groupBy now allows you to not pass any functions or array of functions. e.g. `groupBy(['str'])` or `groupBy(['str'], groupBy.entries())`. Note you could also do `groupBy('str')` (the first argument doesn't need to be an array)
* groupBy now allows you to pass a single function instead of an array if only one: `groupBy(['str'], summarize({ ... }))`
* also update typescript to 4.2.4