### PR TITLE
feat: allow type guards for filter (#39)

### DIFF
--- a/packages/tidy/src/filter.ts
+++ b/packages/tidy/src/filter.ts
@@ -4,6 +4,12 @@ import { TidyFn } from './types';
  * Filters items
  * @param filterFn Returns true to keep the item, false to filter out
  */
+export function filter<T extends object, O extends T>(
+  filterFn: (item: T, index: number, array: T[]) => item is O
+): TidyFn<T, O>;
+export function filter<T extends object>(
+  filterFn: (item: T, index: number, array: T[]) => boolean
+): TidyFn<T>;
 export function filter<T extends object>(
   filterFn: (item: T, index: number, array: T[]) => boolean
 ): TidyFn<T> {


### PR DESCRIPTION
Allows to use type guards with `filter` as shown in #39.
It might make sense to add an example of the use case for filtering `null` values to the documentation. I think this is quite common. But so far there are not many typescript examples in the docs, so I'm not sure if this is desired.