### PR TITLE
fix: fill in undefined columns when joining

### DIFF
--- a/packages/tidy/src/fullJoin.test.ts
+++ b/packages/tidy/src/fullJoin.test.ts
@@ -1,4 +1,4 @@
-import { tidy, fullJoin } from './index';
+import { tidy, fullJoin, select, everything } from './index';
 
 describe('fullJoin', () => {
   it('fullJoin works', () => {
@@ -43,6 +43,71 @@ describe('fullJoin', () => {
       { a: 1, b: 10, c: 100, x: 'x1', y: 'y1' },
       { a: 2, b: 20, c: 200 },
       { a: 5, x: 'x5', y: 'y5' },
+    ]);
+  });
+
+  // note we need this so our lazy functions that just look at first item find all the keys
+  it('puts in explicit undefined for columns when there is no joined item', () => {
+    const results = tidy(
+      [
+        { a: 123, b: 345 },
+        { a: 452, b: 999 },
+      ],
+      fullJoin([{ a: 99, c: 124 }], { by: 'a' })
+    );
+
+    expect(Object.keys(results[0])).toEqual(['a', 'b', 'c']);
+    expect(Object.keys(results[1])).toEqual(['a', 'b', 'c']);
+    expect(Object.keys(results[2])).toEqual(['a', 'b', 'c']);
+
+    const results2 = tidy(
+      [{ a: 99, c: 456 }],
+      fullJoin(
+        [
+          { a: 123, b: 345 },
+          { a: 452, b: 999 },
+        ],
+        { by: 'a' }
+      )
+    );
+
+    expect(Object.keys(results2[0])).toEqual(['a', 'c', 'b']);
+    expect(Object.keys(results2[1])).toEqual(['a', 'c', 'b']);
+    expect(Object.keys(results2[2])).toEqual(['a', 'c', 'b']);
+  });
+
+  it('does not lose columns with select', () => {
+    const results = tidy(
+      [
+        { a: 123, b: 345 },
+        { a: 452, b: 999 },
+      ],
+      fullJoin([{ a: 99, c: 456 }], { by: 'a' }),
+      select([everything()])
+    );
+
+    expect(results).toEqual([
+      { a: 123, b: 345, c: undefined },
+      { a: 452, b: 999, c: undefined },
+      { a: 99, b: undefined, c: 456 },
+    ]);
+
+    const results2 = tidy(
+      [{ a: 99, c: 456 }],
+      fullJoin(
+        [
+          { a: 123, b: 345 },
+          { a: 452, b: 999 },
+        ],
+        { by: 'a' }
+      ),
+      select([everything()])
+    );
+
+    expect(results2).toEqual([
+      { a: 99, c: 456, b: undefined },
+      { a: 123, c: undefined, b: 345 },
+      { a: 452, c: undefined, b: 999 },
     ]);
   });
 

--- a/packages/tidy/src/leftJoin.test.ts
+++ b/packages/tidy/src/leftJoin.test.ts
@@ -1,4 +1,4 @@
-import { tidy, leftJoin } from './index';
+import { tidy, leftJoin, select, everything } from './index';
 
 describe('leftJoin', () => {
   it('leftJoin works', () => {
@@ -36,6 +36,36 @@ describe('leftJoin', () => {
     expect(results3).toEqual([
       { a: 1, b: 10, c: 100, x: 'x1', y: 'y1' },
       { a: 2, b: 20, c: 200 },
+    ]);
+  });
+
+  // note we need this so our lazy functions that just look at first item find all the keys
+  it('puts in explicit undefined for columns when there is no joined item', () => {
+    const results = tidy(
+      [
+        { a: 123, b: 345 },
+        { a: 452, b: 999 },
+      ],
+      leftJoin([{ a: 452, c: 456 }], { by: 'a' })
+    );
+
+    expect(Object.keys(results[0])).toEqual(['a', 'b', 'c']);
+    expect(Object.keys(results[1])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('does not lose columns with select', () => {
+    const results = tidy(
+      [
+        { a: 123, b: 345 },
+        { a: 452, b: 999 },
+      ],
+      leftJoin([{ a: 452, c: 456 }], { by: 'a' }),
+      select([everything()])
+    );
+
+    expect(results).toEqual([
+      { a: 123, b: 345, c: undefined },
+      { a: 452, b: 999, c: 456 },
     ]);
   });
 

--- a/packages/tidy/src/leftJoin.ts
+++ b/packages/tidy/src/leftJoin.ts
@@ -13,15 +13,34 @@ export function leftJoin<T extends Datum, JoinT extends Datum>(
   const _leftJoin: TidyFn<T, O.Merge<T, Partial<JoinT>>> = (
     items: T[]
   ): O.Merge<T, Partial<JoinT>>[] => {
+    if (!itemsToJoin.length) return items as any;
+
     // convert by option in to a map from T key to JoinT key
     const byMap =
       options?.by == null
         ? autodetectByMap(items, itemsToJoin)
         : makeByMap(options.by);
 
+    // when we miss a join, we want to explicitly add in undefined
+    // so our rows all have the same keys. get those keys here.
+    const joinObjectKeys = Object.keys(itemsToJoin[0]);
+
     const joined = items.flatMap((d: T) => {
       const matches = itemsToJoin.filter((j: JoinT) => isMatch(d, j, byMap));
-      return matches.length ? matches.map((j: JoinT) => ({ ...d, ...j })) : d;
+      if (matches.length) {
+        return matches.map((j: JoinT) => ({ ...d, ...j }));
+      }
+
+      // add in missing keys explicitly as undefined without
+      // overriding existing values and while maintaining order
+      // of keys
+      const undefinedFill = Object.fromEntries(
+        joinObjectKeys
+          .filter((key) => d[key] == null)
+          .map((key) => [key, undefined])
+      );
+
+      return { ...d, ...undefinedFill };
     });
 
     return joined;


### PR DESCRIPTION
Fixes #41 by making sure we have all column keys in the same order on all items when joining with left and full join