### PR TITLE
fix: groupBy works with valueOf #46

### DIFF
--- a/packages/tidy/src/groupBy.test.ts
+++ b/packages/tidy/src/groupBy.test.ts
@@ -148,6 +148,28 @@ describe('groupBy / ungroup', () => {
         ])
       );
     });
+
+    it('groupBy works with Dates / valueOf()', () => {
+      const data = [
+        { date: new Date(2021, 0, 1), value: 10 },
+        { date: new Date(2021, 1, 1), value: 20 },
+        { date: new Date(2021, 2, 1), value: 30 },
+        { date: new Date(2021, 0, 1), value: 100 },
+        { date: new Date(2021, 1, 1), value: 200 },
+        { date: new Date(2021, 2, 1), value: 300 },
+      ];
+
+      const results = tidy(
+        data,
+        groupBy('date', [summarize({ value: sum('value') })])
+      );
+
+      expect(results).toEqual([
+        { date: new Date(2021, 0, 1), value: 110 },
+        { date: new Date(2021, 1, 1), value: 220 },
+        { date: new Date(2021, 2, 1), value: 330 },
+      ]);
+    });
   });
 
   describe('ungroup', () => {

--- a/packages/tidy/src/groupBy.ts
+++ b/packages/tidy/src/groupBy.ts
@@ -299,13 +299,15 @@ function makeGrouped<T extends object>(
     return (d: T) => {
       const keyValue = keyFn(d);
 
+      const keyValueOf =
+        typeof keyValue === 'object' ? keyValue.valueOf() : keyValue;
       // used cache tuple if available
-      if (keyCache.has(keyValue)) {
-        return keyCache.get(keyValue) as GroupKey;
+      if (keyCache.has(keyValueOf)) {
+        return keyCache.get(keyValueOf) as GroupKey;
       }
 
       const keyWithName = [key, keyValue];
-      keyCache.set(keyValue, keyWithName);
+      keyCache.set(keyValueOf, keyWithName);
 
       return keyWithName;
     };


### PR DESCRIPTION
caches group keys by checking valueOf(), similar to internmap