### PR TITLE
fix: groupBy works with null values

### DIFF
--- a/packages/tidy/src/groupBy.test.ts
+++ b/packages/tidy/src/groupBy.test.ts
@@ -194,9 +194,6 @@ describe('groupBy / ungroup', () => {
           ],
         ])
       );
-
-      const results2 = tidy(data, groupBy('str', [], groupBy.map()));
-      expect(results2).toEqual(results);
     });
 
     it('groupBy works with Dates / valueOf()', () => {

--- a/packages/tidy/src/groupBy.test.ts
+++ b/packages/tidy/src/groupBy.test.ts
@@ -149,6 +149,56 @@ describe('groupBy / ungroup', () => {
       );
     });
 
+    it('groupBy works with null values', () => {
+      const data = [
+        { str: 'a', ing: 'x', foo: 'G', value: 1 },
+        { str: null, ing: 'x', foo: 'H', value: 100 },
+        { str: 'b', ing: 'x', foo: 'K', value: 200 },
+        { str: null, ing: 'y', foo: 'G', value: 2 },
+        { str: 'a', ing: 'y', foo: 'H', value: 3 },
+        { str: 'a', ing: 'y', foo: 'K', value: 4 },
+        { str: 'b', ing: 'y', foo: 'G', value: 300 },
+        { str: 'b', ing: 'z', foo: 'H', value: 400 },
+        { str: null, ing: 'z', foo: 'K', value: 5 },
+        { str: null, ing: 'z', foo: 'G', value: 6 },
+      ];
+
+      const results = tidy(data, groupBy('str', [], { export: 'map' }));
+
+      expect(results).toEqual(
+        new Map([
+          [
+            null,
+            [
+              { str: null, ing: 'x', foo: 'H', value: 100 },
+              { str: null, ing: 'y', foo: 'G', value: 2 },
+              { str: null, ing: 'z', foo: 'K', value: 5 },
+              { str: null, ing: 'z', foo: 'G', value: 6 },
+            ],
+          ],
+          [
+            'a',
+            [
+              { str: 'a', ing: 'x', foo: 'G', value: 1 },
+              { str: 'a', ing: 'y', foo: 'H', value: 3 },
+              { str: 'a', ing: 'y', foo: 'K', value: 4 },
+            ],
+          ],
+          [
+            'b',
+            [
+              { str: 'b', ing: 'x', foo: 'K', value: 200 },
+              { str: 'b', ing: 'y', foo: 'G', value: 300 },
+              { str: 'b', ing: 'z', foo: 'H', value: 400 },
+            ],
+          ],
+        ])
+      );
+
+      const results2 = tidy(data, groupBy('str', [], groupBy.map()));
+      expect(results2).toEqual(results);
+    });
+
     it('groupBy works with Dates / valueOf()', () => {
       const data = [
         { date: new Date(2021, 0, 1), value: 10 },

--- a/packages/tidy/src/groupBy.ts
+++ b/packages/tidy/src/groupBy.ts
@@ -4,6 +4,7 @@ import { assignGroupKeys } from './helpers/assignGroupKeys';
 import { groupMap } from './helpers/groupMap';
 import { groupTraversal } from './helpers/groupTraversal';
 import { identity } from './helpers/identity';
+import { isObject } from './helpers/isObject';
 import { SingleOrArray, singleOrArray } from './helpers/singleOrArray';
 import { Grouped, GroupKey, TidyGroupExportFn, Key, TidyFn } from './types';
 
@@ -299,8 +300,7 @@ function makeGrouped<T extends object>(
     return (d: T) => {
       const keyValue = keyFn(d);
 
-      const keyValueOf =
-        typeof keyValue === 'object' ? keyValue.valueOf() : keyValue;
+      const keyValueOf = isObject(keyValue) ? keyValue.valueOf() : keyValue;
       // used cache tuple if available
       if (keyCache.has(keyValueOf)) {
         return keyCache.get(keyValueOf) as GroupKey;

--- a/packages/tidy/src/helpers/isObject.ts
+++ b/packages/tidy/src/helpers/isObject.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns true if input is an object
+ */
+export function isObject(obj: any) {
+  const type = typeof obj;
+  return obj != null && (type === 'object' || type === 'function');
+}


### PR DESCRIPTION
The recent change to catch `valueOf()` in group by breaks if `null` is provided as a keyed-upon-value. This PR restores the original tidy behavior of allowing `groupBy` to function with null values. 