### PR TITLE
feat: add AI-optimized genai-docs, llms.txt, and Claude Code skill

### DIFF
--- a/packages/tidy/genai-docs/api-core.md
+++ b/packages/tidy/genai-docs/api-core.md
@@ -1,0 +1,357 @@
+# tidyjs Core API Reference
+
+> AI-optimized reference for the core tidy verbs. These functions go directly inside `tidy()` pipelines.
+> Import: `import { tidy, filter, mutate, transmute, arrange, asc, desc, fixedOrder, select, distinct, rename, when, debug, map } from '@tidyjs/tidy'`
+
+---
+
+<!-- keywords: tidy, pipeline, pipe, chain, flow -->
+## tidy
+
+Run a pipeline of tidy functions on a flat array of objects.
+
+**Signature:** `tidy(items, ...fns) => T[]`
+
+### Parameters
+- `items` -- the input array of objects (`T[]`). Must NOT be a function (throws if it is).
+- `...fns` -- any number of tidy functions to apply sequentially. Output of each is input to the next. Falsy values are skipped.
+
+### Behavior
+- Supports up to 10 chained functions with full TypeScript inference.
+- If the last function is a `groupBy` with an export option, the return type matches the export shape (not necessarily an array).
+- Common mistake: passing a function as the first argument instead of data throws `"You must supply the data as the first argument to tidy()"`.
+
+### Example
+```js
+const data = [
+  { str: 'foo', value: 3 },
+  { str: 'bar', value: 1 },
+  { str: 'bar', value: 7 },
+];
+
+tidy(data,
+  filter((d) => d.value > 1),
+  arrange('value')
+)
+// => [{ str: 'foo', value: 3 }, { str: 'bar', value: 7 }]
+```
+
+---
+
+<!-- keywords: filter, where, predicate, filterFn, keep, remove rows -->
+## filter
+
+Keep only items where the predicate returns true. Equivalent to `Array.prototype.filter`.
+
+**Signature:** `filter(filterFn) => TidyFn<T>`
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+- `filterFn` -- `(item: T, index: number, array: T[]) => boolean`. Returns true to keep the item.
+
+### Example
+```js
+const data = [{ value: 1 }, { value: 2 }, { value: 3 }];
+
+tidy(data, filter((d) => d.value > 1))
+// => [{ value: 2 }, { value: 3 }]
+```
+
+---
+
+<!-- keywords: mutate, add column, modify, transform, mutateSpec, computed column -->
+## mutate
+
+Add or modify columns on each item. Processes items one at a time.
+
+**Signature:** `mutate(mutateSpec) => TidyFn<T, Mutated<T>>`
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+- `mutateSpec` -- an object `{ [key]: value | (item, index, array) => value }`.
+  - If value is a **function**, called as `(item: T, index: number, array: Iterable<T>) => any` per item.
+  - If value is a **non-function**, assigned directly to every item.
+  - Key order matters: later keys can reference values set by earlier keys in the same spec.
+
+### Behavior
+- Each item is shallow-copied (`{ ...item }`) before mutation; the original array is not modified.
+- The mutate function receives the **already-mutated item** (with earlier keys applied), the index, and the mutated array.
+- For mutations that need to look across multiple items (e.g. running totals), use `mutateWithSummary` instead.
+
+### Example
+```js
+const data = [
+  { str: 'foo', value: 3 },
+  { str: 'bar', value: 1 },
+];
+
+tidy(data, mutate({
+  x2: (d) => d.value * 2,
+  x4: (d) => d.x2 * 2,   // references x2 from above
+  constant: 99,
+}))
+// => [
+//   { str: 'foo', value: 3, x2: 6, x4: 12, constant: 99 },
+//   { str: 'bar', value: 1, x2: 2, x4: 4, constant: 99 },
+// ]
+```
+
+---
+
+<!-- keywords: transmute, mutate and select, drop columns, keep only new columns -->
+## transmute
+
+Like `mutate`, but drops all columns not specified in the spec. Internally runs `mutate` then `select` on the spec keys.
+
+**Signature:** `transmute(mutateSpec) => TidyFn<T, ResolvedObj<MSpec>>`
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+- `mutateSpec` -- same as `mutate`. Object `{ [key]: value | (item, index, array) => value }`.
+
+### Example
+```js
+const data = [
+  { str: 'foo', value: 3 },
+  { str: 'bar', value: 1 },
+];
+
+tidy(data, transmute({
+  value_x2: (d) => d.value * 2,
+  value_x4: (d) => d.value_x2 * 2,
+}))
+// => [
+//   { value_x2: 6, value_x4: 12 },
+//   { value_x2: 2, value_x4: 4 },
+// ]
+```
+
+---
+
+<!-- keywords: arrange, sort, order, asc, desc, fixedOrder, comparator, ascending, descending -->
+## arrange
+
+Sort items by keys or comparator functions.
+
+**Signature:** `arrange(comparators) => TidyFn<T>`
+**Goes inside:** `tidy()` pipeline
+**Alias:** `sort`
+
+### Parameters
+- `comparators` -- a single value or array of:
+  - `string` (key name) -- auto-promoted to `asc(key)`.
+  - `(d: T) => any` (single-arg accessor) -- auto-promoted to `asc(accessor)`.
+  - `(a: T, b: T) => number` (two-arg comparator) -- used directly.
+
+### Sorting helpers
+
+- **`asc(key | accessor)`** -- ascending comparator. Nulls/undefined/NaN sort last.
+- **`desc(key | accessor)`** -- descending comparator. Nulls/undefined/NaN sort last.
+- **`fixedOrder(key, order, options?)`** -- sort values by a predefined order array.
+  - `key` -- string key or accessor function.
+  - `order` -- array of values in desired order.
+  - `options.position` -- `'start'` (default) or `'end'`. Items not in the order array appear at the opposite end.
+
+### Example
+```js
+const data = [
+  { str: 'foo', value: 3 },
+  { str: 'bar', value: 5 },
+  { str: 'bar', value: 1 },
+];
+
+tidy(data, arrange(['str', desc('value')]))
+// => [
+//   { str: 'bar', value: 5 },
+//   { str: 'bar', value: 1 },
+//   { str: 'foo', value: 3 },
+// ]
+
+tidy(data, arrange([fixedOrder('str', ['foo', 'bar'])]))
+// => [
+//   { str: 'foo', value: 3 },
+//   { str: 'bar', value: 5 },
+//   { str: 'bar', value: 1 },
+// ]
+```
+
+---
+
+<!-- keywords: select, pick, columns, drop, omit, negate, selectors, everything, startsWith, endsWith, contains, matches, negate -->
+## select
+
+Pick or drop columns from items. Supports selector functions and `-` prefix negation.
+
+**Signature:** `select(selectKeys) => TidyFn<T, Pick<T, ...>>`
+**Goes inside:** `tidy()` pipeline
+**Alias:** `pick`
+
+### Parameters
+- `selectKeys` -- a single key, or an array of:
+  - `string` -- a key name to include.
+  - `'-keyName'` -- a key prefixed with `-` to exclude.
+  - `(items: T[]) => string[]` -- a selector function (e.g. `everything()`, `startsWith('foo')`, `contains('val')`, `matches(/regex/)`, `numRange('x', [1,3])`).
+
+### Behavior
+- If the first key starts with `-`, an implicit `everything()` is prepended (so `-foo` means "all keys except foo").
+- Negations cancel out inclusions: `['a', 'b', '-b']` selects only `a`.
+- Duplicates are removed.
+
+### Example
+```js
+const data = [
+  { foo: 1, bar: 2, baz: 3, qux: 4 },
+];
+
+tidy(data, select(['foo', 'bar']))
+// => [{ foo: 1, bar: 2 }]
+
+tidy(data, select(['-baz', '-qux']))
+// => [{ foo: 1, bar: 2 }]
+
+tidy(data, select([startsWith('b'), '-baz']))
+// => [{ bar: 2 }]
+```
+
+---
+
+<!-- keywords: distinct, unique, deduplicate, dedup, remove duplicates -->
+## distinct
+
+Remove items with duplicate values for the specified keys. Keeps the first occurrence.
+
+**Signature:** `distinct(keys?) => TidyFn<T>`
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+- `keys` (optional) -- a single key/accessor or array of keys/accessors:
+  - `string` -- key name.
+  - `(item: T) => any` -- accessor function.
+  - If omitted or empty, uses strict reference equality on the whole item.
+
+### Example
+```js
+const data = [
+  { str: 'foo', value: 1 },
+  { str: 'foo', value: 3 },
+  { str: 'foo', value: 3 },
+  { str: 'bar', value: 1 },
+];
+
+tidy(data, distinct(['str', 'value']))
+// => [
+//   { str: 'foo', value: 1 },
+//   { str: 'foo', value: 3 },
+//   { str: 'bar', value: 1 },
+// ]
+```
+
+---
+
+<!-- keywords: rename, rename columns, rename keys, renameSpec -->
+## rename
+
+Rename keys in each item. Non-renamed keys are preserved.
+
+**Signature:** `rename(renameSpec) => TidyFn<T, OutputT>`
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+- `renameSpec` -- `{ [oldKey]: 'newKey' }`. Maps existing key names to new names.
+
+### Example
+```js
+const data = [
+  { a: 1, b: 'b10', c: 100 },
+  { a: 2, b: 'b20', c: 200 },
+];
+
+tidy(data, rename({ b: 'label', c: 'score' }))
+// => [
+//   { a: 1, label: 'b10', score: 100 },
+//   { a: 2, label: 'b20', score: 200 },
+// ]
+```
+
+---
+
+<!-- keywords: when, conditional, if, predicate, branch, conditional pipeline -->
+## when
+
+Conditionally run a sub-pipeline. If the predicate is false, items pass through unchanged.
+
+**Signature:** `when(predicate, fns) => TidyFn<T>`
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+- `predicate` -- `boolean | (items: T[]) => boolean`. The condition to evaluate.
+- `fns` -- `TidyFn[]`. Array of tidy functions to run when the predicate is true. Executed as a `tidy()` sub-pipeline.
+
+### Example
+```js
+const data = [{ x: 1 }, { x: 2 }, { x: 3 }];
+
+tidy(data, when(true, [mutate({ y: 10 })]))
+// => [{ x: 1, y: 10 }, { x: 2, y: 10 }, { x: 3, y: 10 }]
+
+tidy(data, when((items) => items.length > 5, [mutate({ y: 10 })]))
+// => [{ x: 1 }, { x: 2 }, { x: 3 }]  (unchanged, predicate was false)
+```
+
+---
+
+<!-- keywords: debug, log, console, inspect, table -->
+## debug
+
+Log the current pipeline state to the console. Data passes through unmodified.
+
+**Signature:** `debug(label?, options?) => TidyFn<T>`
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+- `label` (optional) -- `string`. Label displayed in the console output prefix.
+- `options` (optional) -- `{ limit?: number | null, output?: 'log' | 'table' }`.
+  - `limit` (default `10`) -- max items to display. Set to `null` for all.
+  - `output` (default `'table'`) -- use `console.table` or `console.log`.
+
+### Behavior
+- Output is prefixed with `[tidy.debug]` (plus group keys if inside `groupBy`).
+- Returns items unchanged -- safe to insert anywhere in a pipeline for inspection.
+
+### Example
+```js
+tidy(data,
+  filter((d) => d.value > 1),
+  debug('after filter'),
+  arrange('value')
+)
+// Logs: [tidy.debug] after filter --------
+// (console.table of up to 10 items)
+```
+
+---
+
+<!-- keywords: map, transform, mapFn, convert, reshape -->
+## map
+
+Transform each item to a new shape. Equivalent to `Array.prototype.map`.
+
+**Signature:** `map(mapFn) => TidyFn<T, OutputT>`
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+- `mapFn` -- `(item: T, index: number, array: T[]) => OutputT`. Returns the new item.
+
+### Example
+```js
+const data = [
+  { value: 1, nested: { a: 10, b: 100 } },
+  { value: 2, nested: { a: 20, b: 200 } },
+];
+
+tidy(data, map((d) => ({ value: d.value, ...d.nested })))
+// => [
+//   { value: 1, a: 10, b: 100 },
+//   { value: 2, a: 20, b: 200 },
+// ]
+```

--- a/packages/tidy/genai-docs/api-grouping.md
+++ b/packages/tidy/genai-docs/api-grouping.md
@@ -1,0 +1,400 @@
+# Grouping API Reference
+
+Detailed reference for `groupBy` and its export modes.
+
+```js
+import { tidy, groupBy, summarize, sum, mean, n } from '@tidyjs/tidy';
+```
+
+---
+
+<!-- keywords: groupBy, group, nest, aggregate, split-apply-combine, grouped data -->
+## groupBy
+
+Groups data by one or more keys, runs tidy functions on each group, and returns results either as a flat array (default) or in a structured export format.
+
+**Signature:**
+```ts
+groupBy(
+  groupKeys: string | (d: T) => any | Array<string | (d: T) => any>,
+  fns: TidyFn | TidyFn[],
+  options?: GroupByOptions | ExportShortcut
+)
+```
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+
+- **groupKeys** -- what to group by
+  - `string` -- a property name: `'category'`
+  - `(d) => any` -- an accessor function: `(d) => d.date.getFullYear()`
+  - `Array<string | (d) => any>` -- multiple keys: `['category', 'region']`
+  - Grouping uses strict equality (`===`). For non-primitive keys, return a primitive from an accessor function.
+- **fns** -- tidy functions to run on each group's subset
+  - A single function: `summarize({ total: sum('value') })`
+  - An array of functions: `[filter((d) => d.active), summarize({ n: n() })]`
+- **options?** -- controls output shape
+  - Omitted or `undefined` -- returns a flat array with group keys merged back in (default)
+  - `{ addGroupKeys: false }` -- flat array without merging group keys into results
+  - An export shortcut (`groupBy.object()`, `groupBy.entries()`, etc.) -- returns structured output; makes the function a `TidyGroupExportFn` (must be last in the pipeline)
+
+### Behavior
+
+- Group keys are automatically merged back into each result item (disable with `addGroupKeys: false`).
+- Without an export option, output is a flat `T[]` -- the results from all groups concatenated.
+- With an export option, the return type changes (object, entries, Map, etc.) and the `groupBy` call must be the **last** step in the `tidy()` pipeline.
+
+### Example: Default (flat array)
+
+```js
+const data = [
+  { str: 'a', ing: 'x', value: 1 },
+  { str: 'b', ing: 'x', value: 100 },
+  { str: 'a', ing: 'y', value: 2 },
+  { str: 'b', ing: 'y', value: 300 },
+];
+
+tidy(data, groupBy('str', [summarize({ total: sum('value') })]))
+// output:
+// [
+//   { str: 'a', total: 3 },
+//   { str: 'b', total: 400 }
+// ]
+```
+
+### Example: Multi-key grouping
+
+```js
+tidy(data, groupBy(['str', 'ing'], [summarize({ total: sum('value') })]))
+// output:
+// [
+//   { str: 'a', ing: 'x', total: 1 },
+//   { str: 'a', ing: 'y', total: 2 },
+//   { str: 'b', ing: 'x', total: 100 },
+//   { str: 'b', ing: 'y', total: 300 }
+// ]
+```
+
+### Example: Accessor function as key
+
+```js
+tidy(
+  data,
+  groupBy(
+    (d) => (d.value >= 100 ? 'high' : 'low'),
+    [summarize({ n: n() })]
+  )
+)
+// output:
+// [{ n: 2 }, { n: 2 }]
+// Note: accessor-function keys are not merged back (no property name to use).
+```
+
+---
+
+<!-- keywords: export, entries, nested, key-value pairs -->
+## groupBy.entries()
+
+Returns `[[key, values], ...]` -- an array of `[key, nestedEntriesOrLeafArray]` tuples.
+
+**Signature:** `groupBy.entries(options?: ExportOptions)`
+**Goes inside:** 3rd argument of `groupBy()`
+
+### Example
+
+```js
+tidy(
+  data,
+  groupBy('str', [summarize({ total: sum('value') })], groupBy.entries())
+)
+// output:
+// [
+//   ['a', [{ str: 'a', total: 3 }]],
+//   ['b', [{ str: 'b', total: 400 }]]
+// ]
+```
+
+With `single: true` (unwraps single-item leaf arrays):
+
+```js
+tidy(
+  data,
+  groupBy('str', [summarize({ total: sum('value') })], groupBy.entries({ single: true }))
+)
+// output:
+// [
+//   ['a', { str: 'a', total: 3 }],
+//   ['b', { str: 'b', total: 400 }]
+// ]
+```
+
+---
+
+<!-- keywords: export, entriesObject, key values object -->
+## groupBy.entriesObject()
+
+Returns `[{ key, values }, ...]` -- like `entries()` but as objects instead of tuples.
+
+**Signature:** `groupBy.entriesObject(options?: ExportOptions)`
+**Goes inside:** 3rd argument of `groupBy()`
+
+### Example
+
+```js
+tidy(
+  data,
+  groupBy('str', [summarize({ total: sum('value') })], groupBy.entriesObject())
+)
+// output:
+// [
+//   { key: 'a', values: [{ str: 'a', total: 3 }] },
+//   { key: 'b', values: [{ str: 'b', total: 400 }] }
+// ]
+```
+
+---
+
+<!-- keywords: export, object, dictionary, lookup, key-value -->
+## groupBy.object()
+
+Returns `{ key: values, ... }` -- a plain object keyed by group values.
+
+**Signature:** `groupBy.object(options?: ExportOptions)`
+**Goes inside:** 3rd argument of `groupBy()`
+
+### Example
+
+```js
+tidy(
+  data,
+  groupBy('str', [summarize({ total: sum('value') })], groupBy.object())
+)
+// output:
+// {
+//   a: [{ str: 'a', total: 3 }],
+//   b: [{ str: 'b', total: 400 }]
+// }
+```
+
+Multi-key produces nested objects:
+
+```js
+tidy(
+  data,
+  groupBy(
+    ['str', 'ing'],
+    [summarize({ total: sum('value') })],
+    groupBy.object({ single: true })
+  )
+)
+// output:
+// {
+//   a: {
+//     x: { str: 'a', ing: 'x', total: 1 },
+//     y: { str: 'a', ing: 'y', total: 2 }
+//   },
+//   b: {
+//     x: { str: 'b', ing: 'x', total: 100 },
+//     y: { str: 'b', ing: 'y', total: 300 }
+//   }
+// }
+```
+
+---
+
+<!-- keywords: export, map, ES Map -->
+## groupBy.map()
+
+Returns an ES `Map` where keys are group values (not tuples) and values are nested Maps or leaf arrays.
+
+**Signature:** `groupBy.map(options?: ExportOptions)`
+**Goes inside:** 3rd argument of `groupBy()`
+
+### Example
+
+```js
+tidy(
+  data,
+  groupBy('str', [summarize({ total: sum('value') })], groupBy.map())
+)
+// output:
+// new Map([
+//   ['a', [{ str: 'a', total: 3 }]],
+//   ['b', [{ str: 'b', total: 400 }]]
+// ])
+```
+
+---
+
+<!-- keywords: export, grouped, internal, Grouped Map, tuple keys -->
+## groupBy.grouped()
+
+Returns the raw internal `Grouped<T>` structure -- a `Map` where keys are `[keyName, keyValue]` tuples.
+
+**Signature:** `groupBy.grouped(options?: ExportOptions)`
+**Goes inside:** 3rd argument of `groupBy()`
+
+### Example
+
+```js
+tidy(
+  data,
+  groupBy('str', [summarize({ total: sum('value') })], groupBy.grouped())
+)
+// output:
+// new Map([
+//   [['str', 'a'], [{ str: 'a', total: 3 }]],
+//   [['str', 'b'], [{ str: 'b', total: 400 }]]
+// ])
+```
+
+---
+
+<!-- keywords: export, keys, group keys only -->
+## groupBy.keys()
+
+Returns just the group key values, no data.
+
+**Signature:** `groupBy.keys(options?: ExportOptions)`
+**Goes inside:** 3rd argument of `groupBy()`
+
+### Example
+
+```js
+tidy(
+  data,
+  groupBy('str', [summarize({ total: sum('value') })], groupBy.keys())
+)
+// output:
+// ['a', 'b']
+
+// Multi-key:
+tidy(
+  data,
+  groupBy(['str', 'ing'], [summarize({ total: sum('value') })], groupBy.keys())
+)
+// output:
+// [['a', ['x', 'y']], ['b', ['x', 'y']]]
+```
+
+---
+
+<!-- keywords: export, values, grouped values only -->
+## groupBy.values()
+
+Returns just the grouped value arrays, no keys.
+
+**Signature:** `groupBy.values(options?: ExportOptions)`
+**Goes inside:** 3rd argument of `groupBy()`
+
+### Example
+
+```js
+tidy(
+  data,
+  groupBy('str', [summarize({ total: sum('value') })], groupBy.values())
+)
+// output:
+// [
+//   [{ str: 'a', total: 3 }],
+//   [{ str: 'b', total: 400 }]
+// ]
+```
+
+---
+
+<!-- keywords: export, levels, per-level, mixed export, custom levels -->
+## groupBy.levels()
+
+Per-level export control for multi-key grouping. Each level can use a different export format. The last level specified repeats for remaining levels.
+
+**Signature:** `groupBy.levels(options: ExportOptions & { levels: LevelSpec[] })`
+**Goes inside:** 3rd argument of `groupBy()`
+
+### Parameters (in the options object)
+
+- **levels** (required) -- array of export type strings, one per grouping level:
+  `'entries'` | `'entries-object'` | `'object'` | `'map'` | `'keys'` | `'values'` | `LevelSpec`
+- Plus all common export options (`single`, `flat`, `mapLeaf`, etc.)
+
+### Example
+
+```js
+tidy(
+  data,
+  groupBy(
+    ['str', 'ing'],
+    [summarize({ total: sum('value') })],
+    groupBy.levels({ levels: ['entries-object', 'object'], single: true })
+  )
+)
+// output:
+// [
+//   {
+//     key: 'a',
+//     values: {
+//       x: { str: 'a', ing: 'x', total: 1 },
+//       y: { str: 'a', ing: 'y', total: 2 }
+//     }
+//   },
+//   {
+//     key: 'b',
+//     values: {
+//       x: { str: 'b', ing: 'x', total: 100 },
+//       y: { str: 'b', ing: 'y', total: 300 }
+//     }
+//   }
+// ]
+```
+
+---
+
+<!-- keywords: export options, single, flat, compositeKey, mapLeaf, mapLeaves, mapEntry, addGroupKeys -->
+## Common Export Options
+
+All export shortcut helpers (`groupBy.entries()`, `groupBy.object()`, etc.) accept an options object with these fields:
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `single` | `boolean` | `false` | Unwrap single-item leaf arrays to just the item. Typical after `summarize`. |
+| `flat` | `boolean` | `false` | Flatten nested groups to a single level (multi-key grouping becomes one level). |
+| `compositeKey` | `(keys: any[]) => string` | `keys.join('/')` | Custom function to create flat keys. Only used when `flat: true`. |
+| `mapLeaf` | `(value: T) => any` | identity | Transform each individual leaf item during export. |
+| `mapLeaves` | `(values: T[]) => any` | identity | Transform each leaf array (similar to d3 `rollup`). |
+| `mapEntry` | `(entry: [key, values], level) => any` | identity | Transform each entry (for `entries` export only). |
+| `addGroupKeys` | `boolean` | `true` | Set to `false` to prevent merging group keys back into result objects. |
+
+### Example: flat with compositeKey
+
+```js
+tidy(
+  data,
+  groupBy(
+    ['str', 'ing'],
+    [summarize({ total: sum('value') })],
+    groupBy.object({ flat: true, single: true, compositeKey: (keys) => keys.join('-') })
+  )
+)
+// output:
+// {
+//   'a-x': { str: 'a', ing: 'x', total: 1 },
+//   'a-y': { str: 'a', ing: 'y', total: 2 },
+//   'b-x': { str: 'b', ing: 'x', total: 100 },
+//   'b-y': { str: 'b', ing: 'y', total: 300 }
+// }
+```
+
+### Example: mapLeaves
+
+```js
+tidy(
+  data,
+  groupBy(
+    'str',
+    [summarize({ total: sum('value') })],
+    groupBy.entries({ mapLeaves: (leaves) => leaves.length })
+  )
+)
+// output:
+// [['a', 1], ['b', 1]]
+```

--- a/packages/tidy/genai-docs/api-joins.md
+++ b/packages/tidy/genai-docs/api-joins.md
@@ -1,0 +1,118 @@
+# Joins
+
+Join two collections by matching keys.
+
+```js
+import { tidy, innerJoin, leftJoin, fullJoin } from '@tidyjs/tidy';
+```
+
+---
+
+<!-- keywords: inner join, merge, combine, matching rows -->
+## innerJoin
+
+Keep only rows that have a match in both collections.
+
+**Signature:** `innerJoin<T, JoinT>(itemsToJoin: JoinT[], options?: { by?: string | string[] | Record<string, string> })`
+**Goes inside:** `tidy(data, innerJoin(...))`
+
+### Parameters
+- **itemsToJoin** `JoinT[]` -- the right-side array to join against.
+- **options.by** `string | string[] | { [rightKey]: leftKey }` -- how to match rows. A single key name, array of shared key names, or an object mapping right-side keys to left-side keys. If omitted, auto-detects shared keys from the first elements of each array.
+
+### Example
+```js
+const data = [
+  { id: 1, value: 10 },
+  { id: 2, value: 20 },
+];
+const lookup = [
+  { id: 1, label: 'a' },
+  { id: 3, label: 'c' },
+];
+
+tidy(data, innerJoin(lookup, { by: 'id' }));
+// output: [{ id: 1, value: 10, label: 'a' }]
+// row id=2 dropped (no match), row id=3 dropped (not in left)
+```
+
+---
+
+<!-- keywords: left join, merge, keep all left, nullable right -->
+## leftJoin
+
+Keep all left-side rows. Adds right-side columns where a match exists; fills with `undefined` where no match is found.
+
+**Signature:** `leftJoin<T, JoinT>(itemsToJoin: JoinT[], options?: { by?: string | string[] | Record<string, string> })`
+**Goes inside:** `tidy(data, leftJoin(...))`
+
+### Parameters
+- **itemsToJoin** `JoinT[]` -- the right-side array to join against.
+- **options.by** -- same as `innerJoin`. If omitted, auto-detects shared keys.
+
+### Example
+```js
+const data = [
+  { id: 1, value: 10 },
+  { id: 2, value: 20 },
+];
+const lookup = [
+  { id: 1, label: 'a' },
+];
+
+tidy(data, leftJoin(lookup, { by: 'id' }));
+// output:
+// [
+//   { id: 1, value: 10, label: 'a' },
+//   { id: 2, value: 20, label: undefined },
+// ]
+```
+
+---
+
+<!-- keywords: full join, outer join, merge, keep all rows -->
+## fullJoin
+
+Keep all rows from both sides. Unmatched columns are filled with `undefined`.
+
+**Signature:** `fullJoin<T, JoinT>(itemsToJoin: JoinT[], options?: { by?: string | string[] | Record<string, string> })`
+**Goes inside:** `tidy(data, fullJoin(...))`
+
+### Parameters
+- **itemsToJoin** `JoinT[]` -- the right-side array to join against.
+- **options.by** -- same as `innerJoin`. If omitted, auto-detects shared keys.
+
+### Example
+```js
+const data = [
+  { id: 1, value: 10 },
+  { id: 2, value: 20 },
+];
+const other = [
+  { id: 2, label: 'b' },
+  { id: 3, label: 'c' },
+];
+
+tidy(data, fullJoin(other, { by: 'id' }));
+// output:
+// [
+//   { id: 1, value: 10, label: undefined },
+//   { id: 2, value: 20, label: 'b' },
+//   { id: undefined, value: undefined, label: 'c' },
+// ]
+// id=3 row added from right side with left columns undefined
+```
+
+---
+
+## Joining on different key names
+
+Use an object `{ rightKey: 'leftKey' }` to join when column names differ:
+
+```js
+const orders = [{ orderId: 1, userId: 100 }];
+const users = [{ uid: 100, name: 'Alice' }];
+
+tidy(orders, leftJoin(users, { by: { uid: 'userId' } }));
+// output: [{ orderId: 1, userId: 100, uid: 100, name: 'Alice' }]
+```

--- a/packages/tidy/genai-docs/api-other.md
+++ b/packages/tidy/genai-docs/api-other.md
@@ -1,0 +1,238 @@
+# Other Functions
+
+Miscellaneous tidyjs functions for completing, filling, replacing, adding rows, and math utilities.
+
+```js
+import { tidy, complete, expand, fill, replaceNully, addRows, rate, TMath } from '@tidyjs/tidy';
+```
+
+---
+
+<!-- keywords: complete, fill missing combinations, add missing rows -->
+## complete
+
+Fill in missing combinations of data. Adds rows for any combination of specified keys that does not already exist.
+
+**Signature:** `complete<T>(expandKeys: string | string[] | KeyMap<T>, replaceNullySpec?: Partial<T>)`
+**Goes inside:** `tidy(data, complete(...))`
+
+### Parameters
+- **expandKeys** `string | string[] | KeyMap<T>` -- defines which columns to expand. As a `KeyMap`, each key maps to an array of values or a sequence function (e.g., `fullSeq`).
+- **replaceNullySpec** `Partial<T>` (optional) -- replace null/undefined in newly created rows. E.g., `{ value: 0 }`.
+
+### Example
+```js
+const data = [
+  { group: 'a', year: 2020, value: 10 },
+  { group: 'a', year: 2021, value: 20 },
+  { group: 'b', year: 2020, value: 30 },
+];
+
+tidy(data, complete({ group: ['a', 'b'], year: [2020, 2021] }, { value: 0 }));
+// output:
+// [
+//   { group: 'a', year: 2020, value: 10 },
+//   { group: 'a', year: 2021, value: 20 },
+//   { group: 'b', year: 2020, value: 30 },
+//   { group: 'b', year: 2021, value: 0 },  // added, value filled with 0
+// ]
+```
+
+---
+
+<!-- keywords: expand, all combinations, cartesian product, cross join -->
+## expand
+
+Generate all combinations of the specified keys. Unlike `complete`, returns only the expanded combination rows (does not merge with original data).
+
+**Signature:** `expand<T>(expandKeys: string | string[] | KeyMap<T>)`
+**Goes inside:** `tidy(data, expand(...))`
+
+### Parameters
+- **expandKeys** `string | string[] | KeyMap<T>` -- columns to expand. As a string or array, uses distinct values from the data. As a `KeyMap`, values can be explicit arrays or sequence functions.
+
+### Example
+```js
+const data = [
+  { group: 'a', year: 2020 },
+  { group: 'b', year: 2021 },
+];
+
+tidy(data, expand(['group', 'year']));
+// output: all combinations of distinct group and year values
+// [
+//   { group: 'a', year: 2020 },
+//   { group: 'a', year: 2021 },
+//   { group: 'b', year: 2020 },
+//   { group: 'b', year: 2021 },
+// ]
+```
+
+---
+
+<!-- keywords: fill, fill down, forward fill, last observation carried forward -->
+## fill
+
+Fill null/undefined values forward (downward) using the last non-null value.
+
+**Signature:** `fill<T>(keys: string | string[])`
+**Goes inside:** `tidy(data, fill(...))`
+
+### Parameters
+- **keys** `string | string[]` -- column name(s) to fill.
+
+### Example
+```js
+const data = [
+  { name: 'Alice', value: 10 },
+  { name: undefined, value: 20 },
+  { name: undefined, value: 30 },
+  { name: 'Bob', value: 40 },
+];
+
+tidy(data, fill('name'));
+// output:
+// [
+//   { name: 'Alice', value: 10 },
+//   { name: 'Alice', value: 20 },  // filled from above
+//   { name: 'Alice', value: 30 },  // filled from above
+//   { name: 'Bob', value: 40 },
+// ]
+```
+
+---
+
+<!-- keywords: replace nully, replace null, replace undefined, default values, coalesce -->
+## replaceNully
+
+Replace null or undefined values with specified defaults.
+
+**Signature:** `replaceNully<T>(replaceSpec: Partial<T>)`
+**Goes inside:** `tidy(data, replaceNully(...))`
+
+### Parameters
+- **replaceSpec** `Partial<T>` -- object mapping column names to replacement values. Only null/undefined values are replaced.
+
+### Example
+```js
+const data = [
+  { name: 'Alice', score: null, grade: undefined },
+  { name: 'Bob', score: 85, grade: 'B' },
+];
+
+tidy(data, replaceNully({ score: 0, grade: 'N/A' }));
+// output:
+// [
+//   { name: 'Alice', score: 0, grade: 'N/A' },
+//   { name: 'Bob', score: 85, grade: 'B' },
+// ]
+```
+
+---
+
+<!-- keywords: add rows, add items, append, insert rows -->
+## addRows
+
+Append rows to the data. Alias: `addItems`.
+
+**Signature:** `addRows<T>(itemsToAdd: T | T[] | ((items: T[]) => T | T[]))`
+**Goes inside:** `tidy(data, addRows(...))`
+
+### Parameters
+- **itemsToAdd** `T | T[] | ((items: T[]) => T | T[])` -- rows to append. Can be a single item, an array, or a function that receives the current items and returns new rows.
+
+### Example
+```js
+const data = [{ name: 'Alice', value: 10 }];
+
+tidy(data, addRows([{ name: 'Bob', value: 20 }]));
+// output: [{ name: 'Alice', value: 10 }, { name: 'Bob', value: 20 }]
+
+// dynamic: add a total row
+tidy(data, addRows((items) => ({
+  name: 'Total',
+  value: items.reduce((s, d) => s + d.value, 0),
+})));
+```
+
+---
+
+<!-- keywords: rate, ratio, divide, item accessor, mutate rate -->
+## rate (item accessor)
+
+Create a per-item rate accessor for use inside `mutate()`. Computes `numerator / denominator` for each row.
+
+**Signature:** `rate<T>(numerator: keyof T | Accessor, denominator: keyof T | Accessor, options?: { predicate?, allowDivideByZero? })`
+**Goes inside:** `mutate({ col: rate('num', 'denom') })`
+
+### Parameters
+- **numerator** `keyof T | ((d, i, arr) => number)` -- column name or accessor for the numerator.
+- **denominator** `keyof T | ((d, i, arr) => number)` -- column name or accessor for the denominator.
+- **options.predicate** `(d, i, arr) => boolean` -- if provided, returns `undefined` when predicate is false.
+- **options.allowDivideByZero** `boolean` -- if `true`, allows division by zero (returns `Infinity`). Default: `false` (returns `undefined` when denominator is 0, except 0/0 which returns 0).
+
+### Example
+```js
+const data = [
+  { hits: 30, attempts: 100 },
+  { hits: 0, attempts: 0 },
+  { hits: 5, attempts: 0 },
+];
+
+tidy(data, mutate({ pct: rate('hits', 'attempts') }));
+// output:
+// [
+//   { hits: 30, attempts: 100, pct: 0.3 },
+//   { hits: 0, attempts: 0, pct: 0 },       // 0/0 = 0
+//   { hits: 5, attempts: 0, pct: undefined }, // div by zero = undefined
+// ]
+```
+
+**Do not confuse with `TMath.rate`** (see below), which is a plain math function, not an item accessor.
+
+---
+
+<!-- keywords: TMath, math rate, math add, math subtract, null safe math -->
+## TMath
+
+Plain math utility functions with null/undefined safety. These are standalone functions, not tidy pipeline operators.
+
+```js
+import { TMath } from '@tidyjs/tidy';
+```
+
+### TMath.rate(numerator, denominator, allowDivideByZero?)
+
+Compute `numerator / denominator` with null safety.
+
+- Returns `undefined` if either argument is null/undefined.
+- Returns `0` if both numerator and denominator are 0.
+- Returns `undefined` if denominator is 0 (unless `allowDivideByZero` is `true`).
+
+```js
+TMath.rate(30, 100);       // 0.3
+TMath.rate(0, 0);          // 0
+TMath.rate(5, 0);          // undefined
+TMath.rate(null, 100);     // undefined
+TMath.rate(5, 0, true);    // Infinity
+```
+
+### TMath.add(a, b, nullyZero?)
+
+Null-safe addition. Returns `undefined` if either value is null/undefined, unless `nullyZero` is `true` (treats null/undefined as 0).
+
+```js
+TMath.add(1, 2);           // 3
+TMath.add(1, null);        // undefined
+TMath.add(1, null, true);  // 1
+```
+
+### TMath.subtract(a, b, nullyZero?)
+
+Null-safe subtraction. Returns `undefined` if either value is null/undefined, unless `nullyZero` is `true`.
+
+```js
+TMath.subtract(5, 3);           // 2
+TMath.subtract(5, null);        // undefined
+TMath.subtract(5, null, true);  // 5
+```

--- a/packages/tidy/genai-docs/api-pivot.md
+++ b/packages/tidy/genai-docs/api-pivot.md
@@ -1,0 +1,112 @@
+# Pivot (Reshape)
+
+Reshape data between long and wide formats.
+
+```js
+import { tidy, pivotWider, pivotLonger } from '@tidyjs/tidy';
+```
+
+---
+
+<!-- keywords: pivot wider, spread, long to wide, reshape, widen -->
+## pivotWider
+
+Reshape from long format to wide format by spreading values into new columns.
+
+**Signature:** `pivotWider<T>(options: { namesFrom, valuesFrom, valuesFill?, valuesFillMap?, namesSep? })`
+**Goes inside:** `tidy(data, pivotWider(...))`
+
+### Parameters
+- **namesFrom** `keyof T | (keyof T)[]` -- column(s) whose values become new column names.
+- **valuesFrom** `keyof T | (keyof T)[]` -- column(s) whose values fill the new columns.
+- **valuesFill** `any` -- value to use when a combination has no data. Default: `undefined`.
+- **valuesFillMap** `Record<string, any>` -- per-valuesFrom fill values (e.g., `{ count: 0, total: 0 }`).
+- **namesSep** `string` -- separator when combining multiple namesFrom or valuesFrom keys. Default: `'_'`.
+
+### Example
+```js
+const data = [
+  { name: 'Alice', subject: 'math', score: 90 },
+  { name: 'Alice', subject: 'reading', score: 85 },
+  { name: 'Bob', subject: 'math', score: 70 },
+  { name: 'Bob', subject: 'reading', score: 95 },
+];
+
+tidy(data, pivotWider({
+  namesFrom: 'subject',
+  valuesFrom: 'score',
+  valuesFill: 0,
+}));
+// output:
+// [
+//   { name: 'Alice', math: 90, reading: 85 },
+//   { name: 'Bob', math: 70, reading: 95 },
+// ]
+```
+
+### Multiple valuesFrom
+```js
+tidy(data, pivotWider({
+  namesFrom: 'subject',
+  valuesFrom: ['score', 'grade'],
+  namesSep: '_',
+}));
+// columns become: name, score_math, score_reading, grade_math, grade_reading
+```
+
+---
+
+<!-- keywords: pivot longer, melt, gather, wide to long, unpivot, reshape -->
+## pivotLonger
+
+Reshape from wide format to long format by collapsing columns into rows.
+
+**Signature:** `pivotLonger<T>(options: { cols?, namesTo, valuesTo, namesSep? })`
+**Goes inside:** `tidy(data, pivotLonger(...))`
+
+### Parameters
+- **cols** `(keyof T)[] | SelectorFn` -- columns to pivot into longer format. Accepts an array of column names or selector functions like `startsWith()`, `contains()`, etc.
+- **namesTo** `string | string[]` -- name for the new column(s) that will hold the former column names.
+- **valuesTo** `string | string[]` -- name for the new column(s) that will hold the values.
+- **namesSep** `string` -- separator to split column names when `namesTo` is an array. Default: `'_'`.
+
+### Example
+```js
+const data = [
+  { name: 'Alice', math: 90, reading: 85 },
+  { name: 'Bob', math: 70, reading: 95 },
+];
+
+tidy(data, pivotLonger({
+  cols: ['math', 'reading'],
+  namesTo: 'subject',
+  valuesTo: 'score',
+}));
+// output:
+// [
+//   { name: 'Alice', subject: 'math', score: 90 },
+//   { name: 'Alice', subject: 'reading', score: 85 },
+//   { name: 'Bob', subject: 'math', score: 70 },
+//   { name: 'Bob', subject: 'reading', score: 95 },
+// ]
+```
+
+### Using selectors for cols
+```js
+import { startsWith } from '@tidyjs/tidy';
+
+const data = [
+  { id: 1, rev_q1: 100, rev_q2: 200, cost_q1: 50 },
+];
+
+tidy(data, pivotLonger({
+  cols: [startsWith('rev_')],
+  namesTo: 'quarter',
+  valuesTo: 'revenue',
+}));
+// output:
+// [
+//   { id: 1, cost_q1: 50, quarter: 'rev_q1', revenue: 100 },
+//   { id: 1, cost_q1: 50, quarter: 'rev_q2', revenue: 200 },
+// ]
+```

--- a/packages/tidy/genai-docs/api-selectors.md
+++ b/packages/tidy/genai-docs/api-selectors.md
@@ -1,0 +1,159 @@
+# Selectors
+
+Functions that dynamically select column names based on patterns. Selectors return `(items: T[]) => string[]`.
+
+Use selectors inside `select()`, `summarizeAt()`, `totalAt()`, and `pivotLonger({ cols: ... })`.
+
+```js
+import { tidy, select,
+  everything, startsWith, endsWith, contains, matches, numRange, negate
+} from '@tidyjs/tidy';
+```
+
+---
+
+<!-- keywords: everything, all columns, select all -->
+## everything
+
+Select all columns.
+
+**Signature:** `everything<T>()`
+**Returns:** `(items: T[]) => string[]`
+
+### Example
+```js
+tidy(data, select([everything(), '-secret']));
+// selects all columns except 'secret'
+```
+
+---
+
+<!-- keywords: starts with, prefix, column prefix -->
+## startsWith
+
+Select columns whose names start with a prefix.
+
+**Signature:** `startsWith<T>(prefix: string, ignoreCase?: boolean)`
+**Returns:** `(items: T[]) => string[]`
+
+### Parameters
+- **prefix** `string` -- the prefix to match.
+- **ignoreCase** `boolean` -- case-insensitive matching. Default: `true`.
+
+### Example
+```js
+// data has columns: rev_q1, rev_q2, cost_q1
+tidy(data, select([startsWith('rev_')]));
+// keeps: rev_q1, rev_q2
+```
+
+---
+
+<!-- keywords: ends with, suffix, column suffix -->
+## endsWith
+
+Select columns whose names end with a suffix.
+
+**Signature:** `endsWith<T>(suffix: string, ignoreCase?: boolean)`
+**Returns:** `(items: T[]) => string[]`
+
+### Parameters
+- **suffix** `string` -- the suffix to match.
+- **ignoreCase** `boolean` -- case-insensitive matching. Default: `true`.
+
+### Example
+```js
+// data has columns: name_en, name_fr, age
+tidy(data, select([endsWith('_en')]));
+// keeps: name_en
+```
+
+---
+
+<!-- keywords: contains, substring, column search -->
+## contains
+
+Select columns whose names contain a substring.
+
+**Signature:** `contains<T>(substring: string, ignoreCase?: boolean)`
+**Returns:** `(items: T[]) => string[]`
+
+### Parameters
+- **substring** `string` -- the substring to search for.
+- **ignoreCase** `boolean` -- case-insensitive matching. Default: `true`.
+
+### Example
+```js
+// data has columns: total_revenue, net_revenue, cost
+tidy(data, select([contains('revenue')]));
+// keeps: total_revenue, net_revenue
+```
+
+---
+
+<!-- keywords: matches, regex, pattern, column regex -->
+## matches
+
+Select columns whose names match a regular expression.
+
+**Signature:** `matches<T>(regex: RegExp)`
+**Returns:** `(items: T[]) => string[]`
+
+### Parameters
+- **regex** `RegExp` -- the regular expression to test against.
+
+### Example
+```js
+// data has columns: q1_sales, q2_sales, q1_cost, notes
+tidy(data, select([matches(/^q\d+_sales$/)]));
+// keeps: q1_sales, q2_sales
+```
+
+---
+
+<!-- keywords: num range, numbered columns, prefix with numbers -->
+## numRange
+
+Select columns matching a prefix followed by numbers in a range.
+
+**Signature:** `numRange<T>(prefix: string, range: [number, number], width?: number)`
+**Returns:** `(items: T[]) => string[]`
+
+### Parameters
+- **prefix** `string` -- the column name prefix.
+- **range** `[number, number]` -- inclusive `[start, end]` range of numbers.
+- **width** `number` (optional) -- zero-pad numbers to this width. E.g., `width=3` turns `1` into `001`.
+
+### Example
+```js
+// data has columns: wk1, wk2, wk3, ..., wk52, name
+tidy(data, select([numRange('wk', [1, 4])]));
+// keeps: wk1, wk2, wk3, wk4
+
+// with zero-padded columns: wk001, wk002, ...
+tidy(data, select([numRange('wk', [1, 4], 3)]));
+// keeps: wk001, wk002, wk003, wk004
+```
+
+---
+
+<!-- keywords: negate, invert, exclude, drop columns -->
+## negate
+
+Invert a selector to exclude the matched columns. Prefixes matched keys with `-`.
+
+**Signature:** `negate<T>(selectors: Selector | Selector[])`
+**Returns:** `(items: T[]) => string[]`
+
+### Parameters
+- **selectors** -- one or more selectors (or key names) to invert.
+
+### Example
+```js
+// data has columns: id, rev_q1, rev_q2, cost_q1
+tidy(data, select([negate(startsWith('rev_'))]));
+// drops rev_q1, rev_q2 -- keeps id, cost_q1
+
+// equivalent to:
+tidy(data, select(['-rev_q1', '-rev_q2']));
+```

--- a/packages/tidy/genai-docs/api-sequences.md
+++ b/packages/tidy/genai-docs/api-sequences.md
@@ -1,0 +1,127 @@
+# Sequences
+
+Generate full sequences of values. Typically used inside `complete()` or `expand()` to define the full range of a variable.
+
+```js
+import { tidy, complete, expand,
+  fullSeq, fullSeqDate, fullSeqDateISOString,
+  vectorSeq, vectorSeqDate
+} from '@tidyjs/tidy';
+```
+
+---
+
+<!-- keywords: full sequence, numeric sequence, fill range, step -->
+## fullSeq
+
+Generate a full numeric sequence from min to max of a column's values.
+
+**Signature:** `fullSeq<T>(key: keyof T | ((d: T) => number), period?: number)`
+**Returns:** `(items: T[]) => number[]`
+
+### Parameters
+- **key** `keyof T | ((d: T) => number)` -- column name or accessor to read numeric values from.
+- **period** `number` -- step size between values. Default: `1`.
+
+### Example
+```js
+const data = [
+  { year: 2020, value: 10 },
+  { year: 2023, value: 30 },
+];
+
+tidy(data, complete({ year: fullSeq('year') }));
+// fills in missing years: 2020, 2021, 2022, 2023
+// rows for 2021 and 2022 are added with value: undefined
+```
+
+---
+
+<!-- keywords: full date sequence, date range, granularity, day week month -->
+## fullSeqDate
+
+Generate a full date sequence from min to max of a column's Date values.
+
+**Signature:** `fullSeqDate<T>(key: keyof T | ((d: T) => Date), granularity?: Granularity, period?: number)`
+**Returns:** `(items: T[]) => Date[]`
+
+### Parameters
+- **key** `keyof T | ((d: T) => Date)` -- column name or accessor to read Date values from.
+- **granularity** `Granularity` -- step unit. One of: `'second'` / `'s'`, `'minute'` / `'min'`, `'day'` / `'d'`, `'week'` / `'w'`, `'month'` / `'m'`, `'year'` / `'y'` (and plural forms). Default: `'day'`.
+- **period** `number` -- number of granularity units per step. Default: `1`.
+
+### Example
+```js
+const data = [
+  { date: new Date('2023-01-01'), value: 1 },
+  { date: new Date('2023-01-04'), value: 4 },
+];
+
+tidy(data, complete({ date: fullSeqDate('date', 'day') }));
+// fills in Jan 1, 2, 3, 4 -- adds rows for Jan 2 and Jan 3
+```
+
+---
+
+<!-- keywords: full date sequence ISO, date string, ISO 8601 -->
+## fullSeqDateISOString
+
+Same as `fullSeqDate` but returns ISO 8601 strings instead of Date objects.
+
+**Signature:** `fullSeqDateISOString<T>(key: keyof T | ((d: T) => string), granularity?: Granularity, period?: number)`
+**Returns:** `(items: T[]) => string[]`
+
+### Parameters
+Same as `fullSeqDate`. The key accessor should return a string parseable by `new Date(...)`.
+
+### Example
+```js
+const data = [
+  { date: '2023-01-01', value: 1 },
+  { date: '2023-01-03', value: 3 },
+];
+
+tidy(data, complete({ date: fullSeqDateISOString('date', 'day') }));
+// fills dates as ISO strings: '2023-01-01T00:00:00.000Z', '2023-01-02T00:00:00.000Z', ...
+```
+
+---
+
+<!-- keywords: vector sequence, explicit values, numeric -->
+## vectorSeq
+
+Generate a numeric sequence from an explicit array of values (min to max with a step).
+
+**Signature:** `vectorSeq(values: number[], period?: number): number[]`
+**Returns:** `number[]` (not a factory function -- returns the sequence directly)
+
+### Parameters
+- **values** `number[]` -- array of numbers. The sequence spans from `min(values)` to `max(values)`.
+- **period** `number` -- step size. Default: `1`.
+
+### Example
+```js
+vectorSeq([2, 8], 2);
+// output: [2, 4, 6, 8]
+```
+
+---
+
+<!-- keywords: vector date sequence, explicit date values -->
+## vectorSeqDate
+
+Generate a date sequence from an explicit array of Date values (min to max).
+
+**Signature:** `vectorSeqDate(values: Date[], granularity?: Granularity, period?: number): Date[]`
+**Returns:** `Date[]` (not a factory function -- returns the sequence directly)
+
+### Parameters
+- **values** `Date[]` -- array of Dates. The sequence spans from earliest to latest.
+- **granularity** `Granularity` -- step unit. Default: `'day'`.
+- **period** `number` -- number of granularity units per step. Default: `1`.
+
+### Example
+```js
+vectorSeqDate([new Date('2023-01-01'), new Date('2023-01-03')], 'day');
+// output: [Date(Jan 1), Date(Jan 2), Date(Jan 3)]
+```

--- a/packages/tidy/genai-docs/api-slice.md
+++ b/packages/tidy/genai-docs/api-slice.md
@@ -1,0 +1,137 @@
+# Slice
+
+Subset rows by position, value, or random sampling.
+
+```js
+import { tidy, slice, sliceHead, sliceTail, sliceMin, sliceMax, sliceSample } from '@tidyjs/tidy';
+```
+
+---
+
+<!-- keywords: slice, range, index, subset rows -->
+## slice
+
+Keep rows in a given index range (uses `Array.prototype.slice` semantics).
+
+**Signature:** `slice<T>(start: number, end?: number)`
+**Goes inside:** `tidy(data, slice(...))`
+
+### Parameters
+- **start** `number` -- start index (inclusive). Negative values count from the end.
+- **end** `number` (optional) -- end index (exclusive). If omitted, slices to the end.
+
+### Example
+```js
+const data = [{ v: 1 }, { v: 2 }, { v: 3 }, { v: 4 }, { v: 5 }];
+
+tidy(data, slice(1, 3));
+// output: [{ v: 2 }, { v: 3 }]
+```
+
+---
+
+<!-- keywords: head, first n, top rows, limit -->
+## sliceHead
+
+Keep the first N rows.
+
+**Signature:** `sliceHead<T>(n: number)`
+**Goes inside:** `tidy(data, sliceHead(...))`
+
+### Parameters
+- **n** `number` -- number of rows to keep from the start.
+
+### Example
+```js
+tidy(data, sliceHead(2));
+// output: [{ v: 1 }, { v: 2 }]
+```
+
+---
+
+<!-- keywords: tail, last n, bottom rows -->
+## sliceTail
+
+Keep the last N rows.
+
+**Signature:** `sliceTail<T>(n: number)`
+**Goes inside:** `tidy(data, sliceTail(...))`
+
+### Parameters
+- **n** `number` -- number of rows to keep from the end.
+
+### Example
+```js
+tidy(data, sliceTail(2));
+// output: [{ v: 4 }, { v: 5 }]
+```
+
+---
+
+<!-- keywords: min, smallest, bottom n, order by ascending -->
+## sliceMin
+
+Keep the N rows with the smallest values for a given key.
+
+**Signature:** `sliceMin<T>(n: number, orderBy: string | string[] | Comparator<T>)`
+**Goes inside:** `tidy(data, sliceMin(...))`
+
+### Parameters
+- **n** `number` -- number of rows to keep.
+- **orderBy** `string | string[] | ((a, b) => number)` -- key name(s) to sort ascending by, or a custom comparator function.
+
+### Example
+```js
+const data = [
+  { name: 'a', score: 50 },
+  { name: 'b', score: 10 },
+  { name: 'c', score: 30 },
+  { name: 'd', score: 80 },
+];
+
+tidy(data, sliceMin(2, 'score'));
+// output: [{ name: 'b', score: 10 }, { name: 'c', score: 30 }]
+```
+
+---
+
+<!-- keywords: max, largest, top n, order by descending -->
+## sliceMax
+
+Keep the N rows with the largest values for a given key.
+
+**Signature:** `sliceMax<T>(n: number, orderBy: string | string[] | Comparator<T>)`
+**Goes inside:** `tidy(data, sliceMax(...))`
+
+### Parameters
+- **n** `number` -- number of rows to keep.
+- **orderBy** `string | string[] | ((a, b) => number)` -- key name(s) to sort descending by, or a custom comparator function.
+
+### Example
+```js
+tidy(data, sliceMax(2, 'score'));
+// output: [{ name: 'd', score: 80 }, { name: 'a', score: 50 }]
+```
+
+---
+
+<!-- keywords: sample, random, shuffle -->
+## sliceSample
+
+Keep a random sample of N rows.
+
+**Signature:** `sliceSample<T>(n: number, options?: { replace?: boolean })`
+**Goes inside:** `tidy(data, sliceSample(...))`
+
+### Parameters
+- **n** `number` -- number of rows to sample.
+- **options.replace** `boolean` -- if `true`, sample with replacement (same row can appear multiple times). Default: `false`.
+
+### Example
+```js
+tidy(data, sliceSample(2));
+// output: 2 randomly selected rows (without replacement)
+
+tidy(data, sliceSample(5, { replace: true }));
+// output: 5 rows sampled with replacement (may include duplicates)
+```

--- a/packages/tidy/genai-docs/api-summarize.md
+++ b/packages/tidy/genai-docs/api-summarize.md
@@ -1,0 +1,528 @@
+# Summarize API Reference
+
+> Functions for aggregating data: tidy verbs that reduce collections, and summary helpers that compute single values.
+
+---
+
+## Tidy Verbs (pipeline functions)
+
+These go inside a `tidy()` call: `tidy(data, summarize({...}))`.
+
+---
+
+<!-- keywords: summarize, summarise, aggregate, reduce, group summary, spec -->
+## summarize
+
+Reduces all items to a single summary row based on a spec of summary functions.
+
+**Signature:** `summarize(spec, options?)`
+**Goes inside:** `tidy()` pipeline (or `groupBy()` export functions)
+
+### Parameters
+- `spec` -- `Record<string, (items: T[]) => any>` -- object mapping output keys to summary functions
+- `options?` -- `{ rest?: (key: keyof T) => (items: T[]) => any }` -- `rest` applies a summary function to all keys not in `spec`
+
+### Example
+```js
+import { tidy, summarize, sum, mean, n } from '@tidyjs/tidy';
+
+const data = [
+  { group: 'a', value: 10 },
+  { group: 'a', value: 20 },
+  { group: 'b', value: 30 },
+];
+
+tidy(data, summarize({
+  total: sum('value'),
+  avg: mean('value'),
+  count: n(),
+}))
+// output:
+// [{ total: 60, avg: 20, count: 3 }]
+```
+
+---
+
+<!-- keywords: summarizeAll, summarise all, apply to all columns -->
+## summarizeAll
+
+Applies one summary function to every column.
+
+**Signature:** `summarizeAll(summaryFn)`
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+- `summaryFn` -- `(key: keyof T) => (items: T[]) => any` -- a summary key function (e.g., `sum`, `mean`)
+
+### Example
+```js
+import { tidy, summarizeAll, sum } from '@tidyjs/tidy';
+
+const data = [
+  { x: 1, y: 10 },
+  { x: 2, y: 20 },
+];
+
+tidy(data, summarizeAll(sum))
+// output:
+// [{ x: 3, y: 30 }]
+```
+
+---
+
+<!-- keywords: summarizeIf, summarise if, conditional columns, predicate -->
+## summarizeIf
+
+Applies a summary function only to columns whose values match a predicate.
+
+**Signature:** `summarizeIf(predicateFn, summaryFn)`
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+- `predicateFn` -- `(vector: T[keyof T][]) => boolean` -- receives all values for a column; return `true` to include
+- `summaryFn` -- `(key: keyof T) => (items: T[]) => any` -- summary key function to apply
+
+### Example
+```js
+import { tidy, summarizeIf, sum } from '@tidyjs/tidy';
+
+const data = [
+  { str: 'foo', value: 3 },
+  { str: 'bar', value: 7 },
+];
+
+tidy(data, summarizeIf(
+  (vector) => vector.every(v => typeof v === 'number'),
+  sum
+))
+// output:
+// [{ value: 10 }]
+```
+
+---
+
+<!-- keywords: summarizeAt, summarise at, specific columns, named keys -->
+## summarizeAt
+
+Applies a summary function to specific named columns.
+
+**Signature:** `summarizeAt(keys, summaryFn)`
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+- `keys` -- `(keyof T)[]` -- array of column names to summarize
+- `summaryFn` -- `(key: keyof T) => (items: T[]) => any` -- summary key function to apply
+
+### Example
+```js
+import { tidy, summarizeAt, sum } from '@tidyjs/tidy';
+
+const data = [
+  { a: 1, b: 10, c: 100 },
+  { a: 2, b: 20, c: 200 },
+];
+
+tidy(data, summarizeAt(['a', 'b'], sum))
+// output:
+// [{ a: 3, b: 30 }]
+```
+
+---
+
+<!-- keywords: count, group count, tally by key, frequency -->
+## count
+
+Counts items per group for given keys. Shorthand for `groupBy(key, [tally()])`.
+
+**Signature:** `count(groupKeys, options?)`
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+- `groupKeys` -- `string | string[] | accessor | accessor[]` -- key(s) to group by
+- `options?` -- `{ name?: string, sort?: boolean, wt?: string }`
+  - `name` -- output column name (default `'n'`)
+  - `sort` -- if `true`, sorts descending by count
+  - `wt` -- key to use as weight (sums that column instead of counting)
+
+### Example
+```js
+import { tidy, count } from '@tidyjs/tidy';
+
+const data = [
+  { color: 'red' },
+  { color: 'red' },
+  { color: 'blue' },
+];
+
+tidy(data, count('color', { sort: true }))
+// output:
+// [{ color: 'red', n: 2 }, { color: 'blue', n: 1 }]
+```
+
+---
+
+<!-- keywords: tally, count items, row count, weighted count -->
+## tally
+
+Counts items in the current group (or all items). Use inside `groupBy` exports or standalone.
+
+**Signature:** `tally(options?)`
+**Goes inside:** `tidy()` pipeline (commonly inside `groupBy()` export functions)
+
+### Parameters
+- `options?` -- `{ name?: string, wt?: string }`
+  - `name` -- output column name (default `'n'`)
+  - `wt` -- key to use as weight (sums that column instead of counting)
+
+### Example
+```js
+import { tidy, tally, groupBy } from '@tidyjs/tidy';
+
+const data = [
+  { group: 'a', value: 10 },
+  { group: 'a', value: 20 },
+  { group: 'b', value: 30 },
+];
+
+tidy(data, tally())
+// output:
+// [{ n: 3 }]
+
+tidy(data, tally({ wt: 'value' }))
+// output:
+// [{ n: 60 }]
+```
+
+---
+
+<!-- keywords: total, total row, append summary, grand total -->
+## total
+
+Like `summarize`, but appends the summary as a total row while keeping all original rows.
+
+**Signature:** `total(summarizeSpec, mutateSpec)`
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+- `summarizeSpec` -- `Record<string, (items: T[]) => any>` -- summary functions (same as `summarize` spec)
+- `mutateSpec` -- `Record<string, (items: T[]) => any>` -- mutations to apply to the total row (e.g., set a label)
+
+### Example
+```js
+import { tidy, total, sum } from '@tidyjs/tidy';
+
+const data = [
+  { group: 'a', value: 10 },
+  { group: 'b', value: 20 },
+];
+
+tidy(data, total({ value: sum('value') }, { group: () => 'Total' }))
+// output:
+// [
+//   { group: 'a', value: 10 },
+//   { group: 'b', value: 20 },
+//   { group: 'Total', value: 30 },
+// ]
+```
+
+---
+
+<!-- keywords: totalAll, total all columns -->
+## totalAll
+
+Like `total`, but applies one summary function to all columns.
+
+**Signature:** `totalAll(summaryFn, mutateSpec)`
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+- `summaryFn` -- `(key: keyof T) => (items: T[]) => any` -- summary key function
+- `mutateSpec` -- mutations for the total row
+
+---
+
+<!-- keywords: totalIf, total conditional columns -->
+## totalIf
+
+Like `total`, but applies summary only to columns matching a predicate.
+
+**Signature:** `totalIf(predicateFn, summaryFn, mutateSpec)`
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+- `predicateFn` -- `(vector: T[keyof T][]) => boolean` -- column predicate
+- `summaryFn` -- summary key function
+- `mutateSpec` -- mutations for the total row
+
+---
+
+<!-- keywords: totalAt, total specific columns -->
+## totalAt
+
+Like `total`, but applies summary to specific named columns.
+
+**Signature:** `totalAt(keys, summaryFn, mutateSpec)`
+**Goes inside:** `tidy()` pipeline
+
+### Parameters
+- `keys` -- `(keyof T)[]` -- columns to summarize
+- `summaryFn` -- summary key function
+- `mutateSpec` -- mutations for the total row
+
+---
+
+## Summary Functions (aggregation helpers)
+
+These go inside `summarize()`, `total()`, or `mutateWithSummary()` specs.
+
+They accept a **string key** or **accessor function**: `sum('value')` or `sum((d) => d.value)`.
+They return `(items: T[]) => number|any` -- a function that reduces an array to a single value.
+
+---
+
+<!-- keywords: sum, total, add, aggregate sum, conditional sum, predicate -->
+## sum
+
+Computes the sum of values for a key. Uses d3-array `fsum` for floating-point precision.
+
+**Signature:** `sum(key, options?)`
+**Goes inside:** `summarize()`, `total()`, `mutateWithSummary()` spec
+
+### Parameters
+- `key` -- `string | (d: T, index: number, array: Iterable<T>) => number`
+- `options?` -- `{ predicate?: (d: T, index: number, array: Iterable<T>) => boolean }` -- only sum items matching predicate
+
+### Example
+```js
+tidy(data, summarize({
+  value: sum('value'),
+  fooOnly: sum('value', { predicate: d => d.str === 'foo' }),
+}))
+// input:  [{ str: 'foo', value: 3 }, { str: 'bar', value: 7 }]
+// output: [{ value: 10, fooOnly: 3 }]
+```
+
+---
+
+<!-- keywords: mean, average, avg, arithmetic mean -->
+## mean
+
+Computes the arithmetic mean. Uses `fsum` internally for precision.
+
+**Signature:** `mean(key)`
+**Goes inside:** `summarize()`, `total()`, `mutateWithSummary()` spec
+
+### Parameters
+- `key` -- `string | (d: T, index: number, array: Iterable<T>) => number`
+
+### Example
+```js
+tidy(data, summarize({ avg: mean('value') }))
+// input:  [{ value: 3 }, { value: 1 }, { value: 7 }]
+// output: [{ avg: 3.667 }]
+```
+
+---
+
+<!-- keywords: median, middle value, 50th percentile -->
+## median
+
+Computes the median value (via d3-array).
+
+**Signature:** `median(key)`
+**Goes inside:** `summarize()`, `total()`, `mutateWithSummary()` spec
+
+### Parameters
+- `key` -- `string | (d: T, index: number, array: Iterable<T>) => number`
+
+### Example
+```js
+tidy(data, summarize({ med: median('value') }))
+// input:  [{ value: 3 }, { value: 1 }, { value: 7 }]
+// output: [{ med: 3 }]
+```
+
+---
+
+<!-- keywords: min, minimum, smallest -->
+## min
+
+Returns the minimum value (via d3-array).
+
+**Signature:** `min(key)`
+**Goes inside:** `summarize()`, `total()`, `mutateWithSummary()` spec
+
+### Parameters
+- `key` -- `string | (d: T, index: number, array: Iterable<T>) => number`
+
+### Example
+```js
+tidy(data, summarize({ lo: min('value') }))
+// input:  [{ value: 3 }, { value: 1 }, { value: 7 }]
+// output: [{ lo: 1 }]
+```
+
+---
+
+<!-- keywords: max, maximum, largest, highest -->
+## max
+
+Returns the maximum value (via d3-array).
+
+**Signature:** `max(key)`
+**Goes inside:** `summarize()`, `total()`, `mutateWithSummary()` spec
+
+### Parameters
+- `key` -- `string | (d: T, index: number, array: Iterable<T>) => number`
+
+### Example
+```js
+tidy(data, summarize({ hi: max('value') }))
+// input:  [{ value: 3 }, { value: 1 }, { value: 7 }]
+// output: [{ hi: 7 }]
+```
+
+---
+
+<!-- keywords: n, count, length, number of items, row count, predicate count -->
+## n
+
+Counts the number of items. Takes no key argument.
+
+**Signature:** `n(options?)`
+**Goes inside:** `summarize()`, `total()`, `mutateWithSummary()` spec
+
+### Parameters
+- `options?` -- `{ predicate?: (d: T, index: number, array: Iterable<T>) => boolean }` -- only count items matching predicate
+
+### Example
+```js
+tidy(data, summarize({
+  count: n(),
+  countFoo: n({ predicate: d => d.str === 'foo' }),
+}))
+// input:  [{ str: 'foo', value: 3 }, { str: 'foo', value: 1 }, { str: 'bar', value: 7 }]
+// output: [{ count: 3, countFoo: 2 }]
+```
+
+---
+
+<!-- keywords: nDistinct, distinct count, unique values, count unique, cardinality -->
+## nDistinct
+
+Counts the number of distinct values for a key. By default includes `null` but excludes `undefined`.
+
+**Signature:** `nDistinct(key, options?)`
+**Goes inside:** `summarize()`, `total()`, `mutateWithSummary()` spec
+
+### Parameters
+- `key` -- `string | (d: T, index: number, array: Iterable<T>) => any`
+- `options?` -- `{ includeNull?: boolean, includeUndefined?: boolean }` -- defaults: `includeNull: true`, `includeUndefined: false`
+
+### Example
+```js
+tidy(data, summarize({ numStr: nDistinct('str') }))
+// input:  [{ str: 'foo' }, { str: 'foo' }, { str: 'bar' }]
+// output: [{ numStr: 2 }]
+```
+
+---
+
+<!-- keywords: first, first value, head, pick first -->
+## first
+
+Returns the value of a key from the first item in the collection.
+
+**Signature:** `first(key)`
+**Goes inside:** `summarize()`, `total()`, `mutateWithSummary()` spec
+
+### Parameters
+- `key` -- `string | (d: T) => any`
+
+### Example
+```js
+tidy(data, summarize({ str: first('str'), value: sum('value') }))
+// input:  [{ str: 'foo', value: 3 }, { str: 'bar', value: 7 }]
+// output: [{ str: 'foo', value: 10 }]
+```
+
+---
+
+<!-- keywords: last, last value, tail, pick last -->
+## last
+
+Returns the value of a key from the last item in the collection.
+
+**Signature:** `last(key)`
+**Goes inside:** `summarize()`, `total()`, `mutateWithSummary()` spec
+
+### Parameters
+- `key` -- `string | (d: T) => any`
+
+### Example
+```js
+tidy(data, summarize({ str: last('str'), value: sum('value') }))
+// input:  [{ str: 'foo', value: 3 }, { str: 'bar', value: 7 }]
+// output: [{ str: 'bar', value: 10 }]
+```
+
+---
+
+<!-- keywords: deviation, standard deviation, stdev, spread, dispersion -->
+## deviation
+
+Computes the standard deviation (via d3-array).
+
+**Signature:** `deviation(key)`
+**Goes inside:** `summarize()`, `total()`, `mutateWithSummary()` spec
+
+### Parameters
+- `key` -- `string | (d: T, index: number, array: Iterable<T>) => number`
+
+### Example
+```js
+tidy(data, summarize({ stdev: deviation('value') }))
+// input:  [{ value: 3 }, { value: 1 }, { value: 3 }, { value: 1 }, { value: 7 }]
+// output: [{ stdev: 2.449 }]
+```
+
+---
+
+<!-- keywords: variance, var, spread, dispersion squared -->
+## variance
+
+Computes the variance (via d3-array).
+
+**Signature:** `variance(key)`
+**Goes inside:** `summarize()`, `total()`, `mutateWithSummary()` spec
+
+### Parameters
+- `key` -- `string | (d: T, index: number, array: Iterable<T>) => number`
+
+### Example
+```js
+tidy(data, summarize({ v: variance('value') }))
+// input:  [{ value: 3 }, { value: 1 }, { value: 3 }, { value: 1 }, { value: 7 }]
+// output: [{ v: 6 }]
+```
+
+---
+
+<!-- keywords: meanRate, weighted mean, rate, ratio, numerator denominator -->
+## meanRate
+
+Computes a weighted mean rate by summing numerator and denominator independently, then dividing. Avoids bias from averaging pre-computed rates.
+
+**Signature:** `meanRate(numerator, denominator)`
+**Goes inside:** `summarize()`, `total()`, `mutateWithSummary()` spec
+
+### Parameters
+- `numerator` -- `string | (d: T, index: number, array: Iterable<T>) => number`
+- `denominator` -- `string | (d: T, index: number, array: Iterable<T>) => number`
+
+### Example
+```js
+tidy(data, summarize({ rate: meanRate('hits', 'attempts') }))
+// input:  [{ hits: 3, attempts: 10 }, { hits: 7, attempts: 10 }]
+// output: [{ rate: 0.5 }]
+```

--- a/packages/tidy/genai-docs/api-vector.md
+++ b/packages/tidy/genai-docs/api-vector.md
@@ -1,0 +1,239 @@
+# Vector Functions API Reference
+
+Vector functions produce an array of values equal in length to the input collection. They operate across items (not one at a time), enabling running totals, lookbacks, sliding windows, and row numbering.
+
+**CRITICAL:** Vector functions go inside `mutateWithSummary()`, NOT inside `mutate()`. `mutate` passes items one at a time; `mutateWithSummary` passes the full array. Using vector functions inside `mutate()` will silently produce wrong results.
+
+```js
+import { tidy, mutateWithSummary, cumsum, lag, lead, roll, rowNumber } from '@tidyjs/tidy';
+```
+
+---
+
+<!-- keywords: mutateWithSummary, mutate summary, vector mutate, cross-item, broadcast, array function -->
+## mutateWithSummary
+
+Add or replace columns using functions that receive the full array of items.
+
+**Signature:** `mutateWithSummary(spec: Record<string, (items[]) => value[] | value | NonFunctionValue>)`
+**Goes inside:** `tidy()`
+
+### Parameters
+- `spec` -- an object where each key is a new (or existing) column name and each value is one of:
+  - A function `(items: T[]) => T[keyof T][] | T[keyof T]` -- receives the full array. If it returns an **array**, each element maps to the corresponding item. If it returns a **single value**, that value is broadcast to all items.
+  - A literal value (number, string, etc.) -- broadcast to all items.
+
+### Example
+```js
+const data = [
+  { name: 'a', val: 1 },
+  { name: 'b', val: 2 },
+  { name: 'c', val: 3 },
+];
+
+tidy(data, mutateWithSummary({
+  // array return: each element maps to the corresponding row
+  doubled: (items) => items.map(d => d.val * 2),
+  // single value return: broadcast to every row
+  total: (items) => items.reduce((s, d) => s + d.val, 0),
+  // literal value: broadcast to every row
+  flag: true,
+}));
+// output:
+// [
+//   { name: 'a', val: 1, doubled: 2, total: 6, flag: true },
+//   { name: 'b', val: 2, doubled: 4, total: 6, flag: true },
+//   { name: 'c', val: 3, doubled: 6, total: 6, flag: true },
+// ]
+```
+
+### Why not mutate?
+`mutate` processes items one at a time: `(item, index) => value`. It cannot look at other rows. Vector and summary functions need the full array, so they must go inside `mutateWithSummary`.
+
+---
+
+<!-- keywords: cumsum, cumulative sum, running total, running sum -->
+## cumsum
+
+Cumulative sum. Returns an array of running totals (uses full-precision floating-point summation).
+
+**Signature:** `cumsum(key: keyof T | (d: T, index: number, array: Iterable<T>) => number | null | undefined)`
+**Goes inside:** `mutateWithSummary()`
+
+### Parameters
+- `key` -- a property name (string) or accessor function returning a number. `null`/`undefined` values are skipped (running total stays the same).
+
+### Example
+```js
+const data = [
+  { item: 'a', val: 3 },
+  { item: 'b', val: 1 },
+  { item: 'c', val: null },
+  { item: 'd', val: 5 },
+];
+
+tidy(data, mutateWithSummary({
+  running: cumsum('val'),
+}));
+// output:
+// [
+//   { item: 'a', val: 3,    running: 3 },
+//   { item: 'b', val: 1,    running: 4 },
+//   { item: 'c', val: null, running: 4 },
+//   { item: 'd', val: 5,    running: 9 },
+// ]
+```
+
+---
+
+<!-- keywords: lag, previous value, lookback, offset, delta, difference -->
+## lag
+
+Value from N rows before the current row. Useful for computing deltas (current minus previous).
+
+**Signature:** `lag(key: keyof T | (d: T, index: number, array: Iterable<T>) => any, options?)`
+**Goes inside:** `mutateWithSummary()`
+
+### Parameters
+- `key` -- a property name or accessor function.
+- `options` (optional):
+  - `n` (number, default `1`) -- how many rows back to look.
+  - `default` (any, default `undefined`) -- fill value for the first N items where no previous row exists.
+
+### Example
+```js
+const data = [
+  { day: 1, val: 10 },
+  { day: 2, val: 15 },
+  { day: 3, val: 12 },
+];
+
+tidy(data, mutateWithSummary({
+  prev: lag('val'),
+  prev0: lag('val', { default: 0 }),
+  prev2: lag('val', { n: 2 }),
+}));
+// output:
+// [
+//   { day: 1, val: 10, prev: undefined, prev0: 0,  prev2: undefined },
+//   { day: 2, val: 15, prev: 10,        prev0: 10, prev2: undefined },
+//   { day: 3, val: 12, prev: 15,        prev0: 15, prev2: 10 },
+// ]
+```
+
+---
+
+<!-- keywords: lead, next value, lookahead, forward, offset -->
+## lead
+
+Value from N rows after the current row. Useful for computing forward differences.
+
+**Signature:** `lead(key: keyof T | (d: T, index: number, array: Iterable<T>) => any, options?)`
+**Goes inside:** `mutateWithSummary()`
+
+### Parameters
+- `key` -- a property name or accessor function.
+- `options` (optional):
+  - `n` (number, default `1`) -- how many rows ahead to look.
+  - `default` (any, default `undefined`) -- fill value for the last N items where no next row exists.
+
+### Example
+```js
+const data = [
+  { day: 1, val: 10 },
+  { day: 2, val: 15 },
+  { day: 3, val: 12 },
+];
+
+tidy(data, mutateWithSummary({
+  next: lead('val'),
+  next0: lead('val', { default: 0 }),
+  next2: lead('val', { n: 2 }),
+}));
+// output:
+// [
+//   { day: 1, val: 10, next: 15,        next0: 15, next2: 12 },
+//   { day: 2, val: 15, next: 12,        next0: 12, next2: undefined },
+//   { day: 3, val: 12, next: undefined, next0: 0,  next2: undefined },
+// ]
+```
+
+---
+
+<!-- keywords: roll, rolling, sliding window, moving average, running mean, window function -->
+## roll
+
+Rolling/sliding window operation. Applies a summary function to a window of items as it slides across the array.
+
+**Signature:** `roll(width: number, rollFn: (itemsInWindow: T[], endIndex: number) => any, options?)`
+**Goes inside:** `mutateWithSummary()`
+
+### Parameters
+- `width` (number) -- the window size (number of items).
+- `rollFn` -- a function `(itemsInWindow, endIndex) => value` applied to each window. Typically a summary function like `mean('col')`.
+- `options` (optional):
+  - `partial` (boolean, default `false`) -- if `true`, compute for windows smaller than `width` at the edges. If `false`, those positions are `undefined`.
+  - `align` (`'right'` | `'center'` | `'left'`, default `'right'`) -- window alignment relative to the current row:
+    - `'right'`: current row is the last item in the window (looks back).
+    - `'left'`: current row is the first item in the window (looks forward).
+    - `'center'`: current row is the center of the window.
+
+### Example
+```js
+import { mean } from '@tidyjs/tidy';
+
+const data = [
+  { day: 1, val: 3 },
+  { day: 2, val: 1 },
+  { day: 3, val: 3 },
+  { day: 4, val: 1 },
+  { day: 5, val: 7 },
+];
+
+tidy(data, mutateWithSummary({
+  avg3: roll(3, mean('val')),
+  avg3p: roll(3, mean('val'), { partial: true }),
+}));
+// output:
+// [
+//   { day: 1, val: 3, avg3: undefined,    avg3p: 3/1 },  // partial
+//   { day: 2, val: 1, avg3: undefined,    avg3p: 4/2 },  // partial
+//   { day: 3, val: 3, avg3: 7/3,          avg3p: 7/3 },
+//   { day: 4, val: 1, avg3: 5/3,          avg3p: 5/3 },
+//   { day: 5, val: 7, avg3: 11/3,         avg3p: 11/3 },
+// ]
+```
+
+---
+
+<!-- keywords: rowNumber, row number, index, sequential, numbering -->
+## rowNumber
+
+Assigns sequential row numbers starting from 0 (configurable).
+
+**Signature:** `rowNumber(options?)`
+**Goes inside:** `mutateWithSummary()`
+
+### Parameters
+- `options` (optional):
+  - `startAt` (number, default `0`) -- the number to assign to the first row.
+
+### Example
+```js
+const data = [
+  { name: 'a', val: 10 },
+  { name: 'b', val: 20 },
+  { name: 'c', val: 30 },
+];
+
+tidy(data, mutateWithSummary({
+  row: rowNumber(),
+  row1: rowNumber({ startAt: 1 }),
+}));
+// output:
+// [
+//   { name: 'a', val: 10, row: 0, row1: 1 },
+//   { name: 'b', val: 20, row: 1, row1: 2 },
+//   { name: 'c', val: 30, row: 2, row1: 3 },
+// ]
+```

--- a/packages/tidy/genai-docs/gotchas.md
+++ b/packages/tidy/genai-docs/gotchas.md
@@ -1,0 +1,193 @@
+# Gotchas and Anti-Patterns
+
+Common mistakes AI assistants make when generating tidyjs code, ordered by severity.
+
+---
+
+## 1. Using summary functions inside `mutate()` instead of `mutateWithSummary()`
+
+This is the **most dangerous mistake** — it produces code that runs without errors but returns wrong data.
+
+```js
+// WRONG — sum() receives one item at a time, not the full array
+tidy(data, mutate({ total: sum('value') }))
+
+// CORRECT — mutateWithSummary passes the full array to sum()
+tidy(data, mutateWithSummary({ total: sum('value') }))
+```
+
+**Rule:** If the function needs to see all items (summary functions like `sum`, `mean`, `median`, or vector functions like `cumsum`, `lag`, `lead`), use `mutateWithSummary`. If it only needs the current item, use `mutate`.
+
+---
+
+## 2. Using string column names instead of accessor functions
+
+tidyjs is **not** pandas or SQL. Most verbs require accessor functions.
+
+```js
+// WRONG
+tidy(data, filter('value > 10'))
+tidy(data, mutate({ doubled: 'value * 2' }))
+
+// CORRECT
+tidy(data, filter((d) => d.value > 10))
+tidy(data, mutate({ doubled: (d) => d.value * 2 }))
+```
+
+**Exception:** Summary functions and sort helpers accept string keys as shorthand:
+```js
+sum('value')       // OK — shorthand for sum((d) => d.value)
+asc('name')        // OK — shorthand for ascending sort by name
+desc('value')      // OK — shorthand for descending sort by value
+```
+
+---
+
+## 3. Forgetting the outer `tidy()` wrapper
+
+Every transformation should go through `tidy()`. Verbs are curried — they return functions, not results.
+
+```js
+// WRONG — filter() returns a function, not filtered data
+const result = filter((d) => d.active);
+// result is a function, not an array!
+
+// CORRECT
+const result = tidy(data, filter((d) => d.active));
+```
+
+---
+
+## 4. Confusing `TMath.rate()` with item-level `rate()`
+
+These are two different functions with the same name but different purposes:
+
+```js
+import { rate, TMath } from '@tidyjs/tidy';
+
+// TMath.rate — simple math: (numerator, denominator) => number
+TMath.rate(10, 100); // => 0.1
+
+// rate — item-level mutator for use inside mutate()
+tidy(data, mutate({
+  convRate: rate('conversions', 'impressions')
+}))
+// rate('conversions', 'impressions') creates (d) => d.conversions / d.impressions
+```
+
+---
+
+## 5. Not understanding groupBy export modes
+
+Without an export option, `groupBy` returns a flat array. With one, the output shape changes completely.
+
+```js
+// Returns flat array (default)
+tidy(data, groupBy('type', [summarize({ n: n() })]))
+// => [{ type: 'A', n: 5 }, { type: 'B', n: 3 }]
+
+// Returns a plain object — DIFFERENT output shape
+tidy(data, groupBy('type', [summarize({ n: n() })], groupBy.object()))
+// => { A: [{ type: 'A', n: 5 }], B: [{ type: 'B', n: 3 }] }
+```
+
+**Important:** When using an export mode, `groupBy` must be the **last step** in the pipeline. It returns a non-array type that cannot be piped further.
+
+---
+
+## 6. `select` negation syntax requires negation first
+
+The `-` prefix for excluding columns only works when negation keys come first (or all keys are negations).
+
+```js
+// CORRECT — all negations
+tidy(data, select(['-password', '-secret']))
+
+// CORRECT — negations after selector that produces all keys
+tidy(data, select([everything(), '-password']))
+
+// WRONG — mixing positive and negative keys unpredictably
+tidy(data, select(['name', '-password', 'email']))
+```
+
+---
+
+## 7. `fill()` only fills forward (down), not backward
+
+`fill` replaces `null`/`undefined` with the most recent non-null value going **downward** through the array.
+
+```js
+const data = [
+  { group: 'A', value: 10 },
+  { group: null, value: 20 },
+  { group: null, value: 30 },
+  { group: 'B', value: 40 },
+];
+
+tidy(data, fill('group'))
+// => [{ group: 'A', value: 10 }, { group: 'A', value: 20 },
+//     { group: 'A', value: 30 }, { group: 'B', value: 40 }]
+```
+
+If you need backward fill, sort your data in reverse first, fill, then sort back.
+
+---
+
+## 8. Wrapping accessors in `asc()` unnecessarily
+
+`arrange` auto-promotes single-argument accessor functions to ascending comparators. You don't need `asc()` for the basic case.
+
+```js
+// These are equivalent:
+tidy(data, arrange((d) => d.name))
+tidy(data, arrange(asc('name')))
+
+// Use desc() explicitly for descending:
+tidy(data, arrange(desc('value')))
+
+// Multiple sort keys:
+tidy(data, arrange(asc('category'), desc('value')))
+```
+
+---
+
+## 9. Relying on join auto-detection for `by` keys
+
+`innerJoin`, `leftJoin`, and `fullJoin` auto-detect matching keys from the **first element** of each array. This can break with inconsistent data shapes.
+
+```js
+// RISKY — auto-detects join keys from first element
+tidy(data, leftJoin(lookupTable))
+
+// SAFER — explicitly specify join keys
+tidy(data, leftJoin(lookupTable, { by: 'id' }))
+tidy(data, leftJoin(lookupTable, { by: { id: 'lookupId' } }))
+```
+
+---
+
+## 10. Exceeding the 10-step pipeline type limit
+
+`tidy()` has TypeScript overloads for up to 10 pipeline steps. Beyond that, types fall back to `any`.
+
+```js
+// If you need more than 10 steps, split into multiple tidy() calls:
+const intermediate = tidy(data, step1(), step2(), /* ...up to 10 */);
+const result = tidy(intermediate, step11(), step12());
+```
+
+---
+
+## 11. Using `summarize` when you want `total`
+
+`summarize` reduces to a single row. `total` appends a summary row while keeping all original rows.
+
+```js
+// summarize: replaces all rows with one summary row
+tidy(data, summarize({ sum: sum('value') }))
+// => [{ sum: 150 }]
+
+// total: keeps all rows, adds a summary row at the end
+tidy(data, total({ value: sum('value') }))
+// => [{ name: 'a', value: 50 }, { name: 'b', value: 100 }, { name: 'Total', value: 150 }]
+```

--- a/packages/tidy/genai-docs/index.md
+++ b/packages/tidy/genai-docs/index.md
@@ -1,0 +1,44 @@
+# @tidyjs/tidy — AI Documentation
+
+> Tidy up your data with JavaScript! A data wrangling library inspired by R's dplyr and the tidyverse.
+
+## How to Use These Docs
+
+1. **Start here** — Read `mental-model.md` first. It teaches the pipeline pattern, accessor conventions, and function taxonomy that are essential for writing correct tidyjs code.
+2. **Look up functions** — Use the `api-*.md` files to find specific function signatures, parameters, and examples.
+3. **Find recipes** — Check `patterns.md` for multi-step transformation recipes.
+4. **Avoid mistakes** — Read `gotchas.md` for common AI mistakes and anti-patterns.
+5. **Quick lookup** — Use `quick-reference.md` to map a task ("I want to filter rows") to the right function.
+
+## File Index
+
+| File | Purpose |
+|------|---------|
+| [`mental-model.md`](mental-model.md) | Core concepts: pipeline pattern, accessors, function taxonomy, mutate vs mutateWithSummary |
+| [`quick-reference.md`](quick-reference.md) | Task-to-function cheat sheet |
+| [`gotchas.md`](gotchas.md) | Common mistakes and anti-patterns |
+| [`patterns.md`](patterns.md) | Multi-verb recipes for real-world tasks |
+| [`api-core.md`](api-core.md) | tidy, filter, mutate, transmute, arrange, select, distinct, rename, when, debug, map |
+| [`api-grouping.md`](api-grouping.md) | groupBy + all 8 export modes |
+| [`api-summarize.md`](api-summarize.md) | summarize, summarizeAll/At/If + summary functions (sum, mean, median, etc.) |
+| [`api-vector.md`](api-vector.md) | mutateWithSummary + vector functions (cumsum, lag, lead, roll, rowNumber) |
+| [`api-joins.md`](api-joins.md) | innerJoin, leftJoin, fullJoin |
+| [`api-pivot.md`](api-pivot.md) | pivotWider, pivotLonger |
+| [`api-slice.md`](api-slice.md) | slice, sliceHead, sliceTail, sliceMin, sliceMax, sliceSample |
+| [`api-selectors.md`](api-selectors.md) | everything, startsWith, endsWith, contains, matches, numRange, negate |
+| [`api-sequences.md`](api-sequences.md) | fullSeq, fullSeqDate, fullSeqDateISOString, vectorSeq, vectorSeqDate |
+| [`api-other.md`](api-other.md) | complete, expand, fill, replaceNully, count, tally, total, addRows, TMath |
+
+## Quick Install
+
+```bash
+npm install @tidyjs/tidy
+```
+
+```js
+import { tidy, filter, mutate, arrange, desc, groupBy, summarize, sum } from '@tidyjs/tidy';
+```
+
+## Extension Packages
+
+- `@tidyjs/tidy-moment` — Moment.js date/time extensions (not covered in these docs)

--- a/packages/tidy/genai-docs/mental-model.md
+++ b/packages/tidy/genai-docs/mental-model.md
@@ -1,0 +1,270 @@
+# Mental Model for tidyjs
+
+## What is tidyjs?
+
+tidyjs is a JavaScript/TypeScript library for data wrangling that works with **plain arrays of objects** — no special DataFrame wrapper. It is inspired by R's dplyr and the tidyverse. Think of it as a functional pipeline for transforming `{key: value}[]` data, similar to how you might chain SQL operations or pandas methods, but using composable JavaScript functions.
+
+## The Pipeline Pattern
+
+Everything in tidyjs flows through `tidy()`:
+
+```js
+import { tidy, filter, mutate, arrange, desc } from '@tidyjs/tidy';
+
+const result = tidy(
+  data,          // 1st arg: array of objects
+  filter(...),   // 2nd+ args: transformation functions (verbs)
+  mutate(...),
+  arrange(desc('value'))
+);
+// result is a new array of objects
+```
+
+**Key rules:**
+- First argument is always the data array — `tidy(data, ...fns)`
+- Each subsequent argument is a **verb** — a function that returns a `TidyFn`
+- Verbs are **curried**: `filter(predicate)` returns a function `(items[]) => items[]`
+- The output of each verb feeds into the next
+- `tidy()` returns a new array (never mutates the input)
+- You can pass up to **10 pipeline steps** with full TypeScript type inference
+
+**Common mistake — don't call verbs directly:**
+
+```js
+// WRONG: calling filter directly without tidy()
+const result = filter((d) => d.value > 10)(data);
+
+// CORRECT: use tidy() as the pipeline
+const result = tidy(data, filter((d) => d.value > 10));
+```
+
+## Accessor Functions
+
+tidyjs uses **accessor functions** `(d) => d.column` to reference data fields, NOT string column names.
+
+```js
+// CORRECT: accessor function
+tidy(data, filter((d) => d.age > 30))
+tidy(data, mutate({ fullName: (d) => `${d.first} ${d.last}` }))
+
+// WRONG: string column names (this is NOT pandas or SQL)
+tidy(data, filter('age > 30'))  // won't work
+```
+
+**Exception:** Some summary functions accept either a key string or accessor for convenience:
+```js
+sum('value')              // shorthand — string key
+sum((d) => d.value)       // equivalent — accessor function
+mean('score')             // string key shorthand
+```
+
+These are the **only** places strings work as field references: inside summary functions like `sum`, `mean`, `min`, `max`, `median`, `first`, `last`, `n`, `nDistinct`, `deviation`, `variance`, and sort helpers like `asc('key')`, `desc('key')`.
+
+## The Function Taxonomy
+
+This is **critical** — each function type belongs in a specific context:
+
+### Tidy Verbs → go directly inside `tidy()`
+
+These are pipeline steps that transform the array:
+
+```js
+tidy(data,
+  filter((d) => d.active),        // filter rows
+  mutate({ tax: (d) => d.price * 0.1 }), // add/modify columns per item
+  arrange(desc('price')),          // sort rows
+  select(['name', 'price', 'tax']), // pick columns
+  distinct(['category']),          // deduplicate
+  rename({ old_name: 'new_name' }) // rename columns
+)
+```
+
+Full list: `filter`, `mutate`, `transmute`, `mutateWithSummary`, `arrange` (alias: `sort`), `select` (alias: `pick`), `distinct`, `rename`, `slice`, `sliceHead`, `sliceTail`, `sliceMin`, `sliceMax`, `sliceSample`, `groupBy`, `summarize`, `summarizeAll`, `summarizeAt`, `summarizeIf`, `total`, `totalAll`, `totalAt`, `totalIf`, `count`, `tally`, `innerJoin`, `leftJoin`, `fullJoin`, `pivotWider`, `pivotLonger`, `complete`, `expand`, `fill`, `replaceNully`, `addRows` (alias: `addItems`), `when`, `map`, `debug`
+
+### Summary Functions → go inside `summarize()` or `total()`
+
+These **reduce** an array of items to a single value:
+
+```js
+tidy(data,
+  summarize({
+    totalRevenue: sum('revenue'),
+    avgScore: mean('score'),
+    count: n(),
+  })
+)
+// => [{ totalRevenue: 1500, avgScore: 85, count: 10 }]
+```
+
+Summary functions: `sum`, `mean`, `median`, `min`, `max`, `n`, `nDistinct`, `first`, `last`, `deviation`, `variance`, `meanRate`
+
+**They also work inside `mutateWithSummary()`** to add summary-derived columns back to every row.
+
+### Vector Functions → go inside `mutateWithSummary()`
+
+These operate on the **full array** and return a new array of the same length:
+
+```js
+tidy(data,
+  mutateWithSummary({
+    runningTotal: cumsum('value'),
+    prevValue: lag('value'),
+    nextValue: lead('value'),
+    rank: rowNumber(),
+  })
+)
+```
+
+Vector functions: `cumsum`, `lag`, `lead`, `roll`, `rowNumber`
+
+### Item Functions → go inside `mutate()`
+
+These transform **one item at a time**:
+
+```js
+tidy(data,
+  mutate({
+    conversionRate: rate('conversions', 'impressions'),
+  })
+)
+```
+
+Item functions: `rate`
+
+### Selectors → go inside `select()`, `summarizeAt()`, `pivotLonger(cols:)`
+
+These dynamically select columns by pattern:
+
+```js
+tidy(data,
+  select([startsWith('revenue_'), 'name'])
+)
+```
+
+Selectors: `everything`, `startsWith`, `endsWith`, `contains`, `matches`, `numRange`, `negate`
+
+## mutate vs mutateWithSummary
+
+This is the **most important distinction** in tidyjs. Getting this wrong produces silent bugs — code that runs but returns incorrect data.
+
+### `mutate` — per-item transformation
+
+The function receives `(item, index, array)` for each item individually:
+
+```js
+tidy(data,
+  mutate({
+    doubled: (d) => d.value * 2,
+    label: (d) => `${d.name}: ${d.value}`,
+    constant: 42,  // non-function values are applied to all items
+  })
+)
+```
+
+### `mutateWithSummary` — cross-item transformation
+
+The function receives the **entire array** `(items[])` and must return an array of the same length OR a single value (broadcast to all items):
+
+```js
+tidy(data,
+  mutateWithSummary({
+    runningTotal: cumsum('value'),     // returns array
+    pctOfTotal: (items) =>             // custom: returns array
+      items.map(d => d.value / sum('value')(items)),
+    totalValue: sum('value'),          // returns single value → broadcast
+  })
+)
+```
+
+### When to use which?
+
+| Use `mutate` when... | Use `mutateWithSummary` when... |
+|---|---|
+| Each item's new value depends only on that item | New value depends on other items in the array |
+| Simple calculations: `(d) => d.a + d.b` | Cumulative ops: `cumsum`, `lag`, `lead`, `roll` |
+| String formatting: `(d) => d.name.toUpperCase()` | Summary-derived: adding `sum()` or `mean()` as a column |
+| Setting constants: `{ status: 'active' }` | Row numbering: `rowNumber()` |
+
+### The dangerous mistake
+
+```js
+// WRONG — sum() inside mutate() does NOT work correctly
+// sum() expects the full array, but mutate passes one item at a time
+tidy(data, mutate({ total: sum('value') }))
+
+// CORRECT — use mutateWithSummary for cross-item operations
+tidy(data, mutateWithSummary({ total: sum('value') }))
+```
+
+## groupBy Semantics
+
+`groupBy` splits data into groups, runs operations per-group, then recombines:
+
+```js
+tidy(data,
+  groupBy('category', [
+    summarize({ total: sum('value') })
+  ])
+)
+// => [{ category: 'A', total: 100 }, { category: 'B', total: 200 }]
+```
+
+**Key behaviors:**
+- Group keys are automatically merged back into results (disable with `addGroupKeys: false`)
+- Operations inside the `fns` array run on each group independently
+- Without an export option, results are flattened back to a single array (ungrouped)
+- Group by multiple keys: `groupBy(['category', 'region'], [...])`
+- Group by computed key: `groupBy((d) => d.date.getFullYear(), [...])`
+
+### Export Modes
+
+By default, `groupBy` ungroups the result back into a flat array. Use export mode shortcuts to get different output shapes:
+
+```js
+// Flat array (default — no export option)
+groupBy('key', [summarize(...)])
+// => [{ key: 'a', total: 10 }, { key: 'b', total: 20 }]
+
+// Nested entries: [[key, values], ...]
+groupBy('key', [summarize(...)], groupBy.entries())
+
+// Entries as objects: [{ key, values }, ...]
+groupBy('key', [summarize(...)], groupBy.entriesObject())
+
+// Plain object: { key: values, ... }
+groupBy('key', [summarize(...)], groupBy.object())
+
+// ES Map: Map { key => values }
+groupBy('key', [summarize(...)], groupBy.map())
+
+// Grouped Map (raw internal structure)
+groupBy('key', [summarize(...)], groupBy.grouped())
+
+// Just the keys
+groupBy('key', [summarize(...)], groupBy.keys())
+
+// Just the values (arrays)
+groupBy('key', [summarize(...)], groupBy.values())
+
+// Per-level control for multi-level grouping
+groupBy(['cat', 'subcat'], [summarize(...)], groupBy.levels({ levels: ['object', 'entries'] }))
+```
+
+Export options also accept: `flat`, `single`, `mapLeaf`, `mapLeaves`, `mapEntry`, `compositeKey`.
+
+**Important:** When using an export mode, `groupBy` becomes a `TidyGroupExportFn` — it must be the **last step** in the `tidy()` pipeline (or used inside another `groupBy`).
+
+## TypeScript Tips
+
+- **Accessor typing:** `(d: MyType) => d.value` gives full type inference inside `mutate`, `filter`, etc.
+- **Pipeline step limit:** `tidy()` has type overloads for up to 10 steps. For longer pipelines, split into multiple `tidy()` calls or use `as` assertions.
+- **groupBy return types:** The return type changes based on the export option. `groupBy.object()` returns `ObjectOutput`, `groupBy.entries()` returns `EntriesOutput`, etc. Without an export option, it returns the flat array type.
+- **Summary function keys:** `sum('value')` infers the key must exist on the input type. Use accessor functions `sum((d) => d.value)` for computed values.
+
+## What tidyjs is NOT
+
+- **Not a DataFrame wrapper** — works directly with `{key: value}[]` arrays, no special data structure
+- **Not lazy-evaluated** — each verb executes immediately in the pipeline
+- **Not a database query builder** — all data is in memory
+- **Not a charting library** — it transforms data; use a separate library to visualize
+- **Not a replacement for lodash/Array methods** — use it when you need multi-step data wrangling pipelines; for simple `.filter()` or `.map()`, plain JS is fine

--- a/packages/tidy/genai-docs/patterns.md
+++ b/packages/tidy/genai-docs/patterns.md
@@ -1,0 +1,384 @@
+# Patterns and Recipes
+
+Multi-verb recipes for common data transformation tasks.
+
+---
+
+## 1. Group and Summarize
+
+The most common tidyjs pattern — split data into groups, then aggregate each group.
+
+```js
+const data = [
+  { category: 'A', region: 'east', value: 10 },
+  { category: 'A', region: 'west', value: 20 },
+  { category: 'B', region: 'east', value: 30 },
+  { category: 'B', region: 'west', value: 40 },
+];
+
+tidy(data,
+  groupBy('category', [
+    summarize({
+      total: sum('value'),
+      avg: mean('value'),
+      count: n(),
+    })
+  ])
+)
+// => [
+//   { category: 'A', total: 30, avg: 15, count: 2 },
+//   { category: 'B', total: 70, avg: 35, count: 2 },
+// ]
+```
+
+**With multiple group keys:**
+
+```js
+tidy(data,
+  groupBy(['category', 'region'], [
+    summarize({ total: sum('value') })
+  ])
+)
+// => [
+//   { category: 'A', region: 'east', total: 10 },
+//   { category: 'A', region: 'west', total: 20 },
+//   { category: 'B', region: 'east', total: 30 },
+//   { category: 'B', region: 'west', total: 40 },
+// ]
+```
+
+**Export as a keyed object:**
+
+```js
+tidy(data,
+  groupBy('category', [
+    summarize({ total: sum('value') })
+  ], groupBy.object({ single: true }))
+)
+// => { A: { category: 'A', total: 30 }, B: { category: 'B', total: 70 } }
+```
+
+---
+
+## 2. Pivot Wider and Longer
+
+### Long to wide
+
+```js
+const data = [
+  { name: 'Alice', metric: 'score', value: 90 },
+  { name: 'Alice', metric: 'rank', value: 1 },
+  { name: 'Bob', metric: 'score', value: 80 },
+  { name: 'Bob', metric: 'rank', value: 2 },
+];
+
+tidy(data,
+  pivotWider({
+    namesFrom: 'metric',
+    valuesFrom: 'value',
+  })
+)
+// => [
+//   { name: 'Alice', score: 90, rank: 1 },
+//   { name: 'Bob', score: 80, rank: 2 },
+// ]
+```
+
+### Wide to long
+
+```js
+const data = [
+  { name: 'Alice', score: 90, rank: 1 },
+  { name: 'Bob', score: 80, rank: 2 },
+];
+
+tidy(data,
+  pivotLonger({
+    cols: ['score', 'rank'],
+    namesTo: 'metric',
+    valuesTo: 'value',
+  })
+)
+// => [
+//   { name: 'Alice', metric: 'score', value: 90 },
+//   { name: 'Alice', metric: 'rank', value: 1 },
+//   { name: 'Bob', metric: 'score', value: 80 },
+//   { name: 'Bob', metric: 'rank', value: 2 },
+// ]
+```
+
+**Pivot longer with selectors:**
+
+```js
+tidy(data,
+  pivotLonger({
+    cols: [startsWith('q')],  // columns like q1, q2, q3, q4
+    namesTo: 'quarter',
+    valuesTo: 'revenue',
+  })
+)
+```
+
+---
+
+## 3. Fill Missing Time Series (expand + complete + fill)
+
+Generate missing time periods and fill forward.
+
+```js
+const data = [
+  { date: '2024-01', category: 'A', value: 10 },
+  { date: '2024-03', category: 'A', value: 30 },  // 2024-02 missing
+  { date: '2024-01', category: 'B', value: 20 },
+  { date: '2024-02', category: 'B', value: 25 },
+];
+
+tidy(data,
+  complete({
+    date: ['2024-01', '2024-02', '2024-03'],
+    category: ['A', 'B'],
+  }),
+  fill('value')
+)
+// => all date/category combinations exist, nulls filled forward
+```
+
+**With numeric sequences:**
+
+```js
+tidy(data,
+  complete({
+    year: fullSeq('year', { period: 1 }),  // fills gaps in year column
+    category: ['A', 'B'],
+  }),
+  replaceNully({ value: 0 })  // fill missing with 0 instead of forward-fill
+)
+```
+
+---
+
+## 4. Rolling Aggregation
+
+Compute a moving average or other rolling window calculation.
+
+```js
+const data = [
+  { date: '2024-01', value: 10 },
+  { date: '2024-02', value: 20 },
+  { date: '2024-03', value: 15 },
+  { date: '2024-04', value: 25 },
+  { date: '2024-05', value: 30 },
+];
+
+tidy(data,
+  mutateWithSummary({
+    movingAvg3: roll(3, mean('value'), { partial: true }),
+  })
+)
+// => each row gets a 3-period moving average of 'value'
+// partial: true means first 2 rows use windows smaller than 3
+```
+
+**Rolling sum:**
+
+```js
+tidy(data,
+  mutateWithSummary({
+    rollingSum: roll(3, sum('value')),
+  })
+)
+```
+
+---
+
+## 5. Cumulative Calculations
+
+Add a running total, cumulative count, or percentage of total.
+
+```js
+const data = [
+  { month: 'Jan', revenue: 100 },
+  { month: 'Feb', revenue: 150 },
+  { month: 'Mar', revenue: 200 },
+];
+
+tidy(data,
+  mutateWithSummary({
+    cumulativeRevenue: cumsum('revenue'),
+    rowNum: rowNumber(),
+    totalRevenue: sum('revenue'),  // broadcast single value to all rows
+  }),
+  mutate({
+    pctOfTotal: (d) => d.revenue / d.totalRevenue,
+  })
+)
+// => [
+//   { month: 'Jan', revenue: 100, cumulativeRevenue: 100, rowNum: 0, totalRevenue: 450, pctOfTotal: 0.222 },
+//   { month: 'Feb', revenue: 150, cumulativeRevenue: 250, rowNum: 1, totalRevenue: 450, pctOfTotal: 0.333 },
+//   { month: 'Mar', revenue: 200, cumulativeRevenue: 450, rowNum: 2, totalRevenue: 450, pctOfTotal: 0.444 },
+// ]
+```
+
+---
+
+## 6. Conditional Pipeline Branching
+
+Apply transformations only when a condition is met.
+
+```js
+const includeInactive = false;
+
+tidy(data,
+  when(includeInactive, []),  // no-op when false
+  when(!includeInactive, [filter((d) => d.active)]),  // filter when true
+  arrange(desc('value'))
+)
+```
+
+**With a predicate function:**
+
+```js
+tidy(data,
+  when(
+    (items) => items.length > 100,  // only filter if dataset is large
+    [sliceHead(100)]
+  ),
+  summarize({ avg: mean('score') })
+)
+```
+
+---
+
+## 7. Multi-Level Grouping with Export
+
+Nested grouping with per-level export control.
+
+```js
+const data = [
+  { dept: 'Eng', team: 'Frontend', name: 'Alice', salary: 100 },
+  { dept: 'Eng', team: 'Frontend', name: 'Bob', salary: 110 },
+  { dept: 'Eng', team: 'Backend', name: 'Carol', salary: 120 },
+  { dept: 'Sales', team: 'Enterprise', name: 'Dave', salary: 90 },
+];
+
+// Nested object: { dept: { team: [items] } }
+tidy(data,
+  groupBy(['dept', 'team'], [],
+    groupBy.levels({ levels: ['object', 'object'] })
+  )
+)
+// => {
+//   Eng: { Frontend: [Alice, Bob], Backend: [Carol] },
+//   Sales: { Enterprise: [Dave] }
+// }
+```
+
+**Flat export with composite keys:**
+
+```js
+tidy(data,
+  groupBy(['dept', 'team'], [summarize({ total: sum('salary') })],
+    groupBy.object({ flat: true, compositeKey: (keys) => keys.join(' > ') })
+  )
+)
+// => { 'Eng > Frontend': [...], 'Eng > Backend': [...], 'Sales > Enterprise': [...] }
+```
+
+---
+
+## 8. Join and Enrich
+
+Add columns from a lookup table.
+
+```js
+const orders = [
+  { orderId: 1, productId: 'A', qty: 5 },
+  { orderId: 2, productId: 'B', qty: 3 },
+  { orderId: 3, productId: 'A', qty: 2 },
+];
+
+const products = [
+  { productId: 'A', name: 'Widget', price: 10 },
+  { productId: 'B', name: 'Gadget', price: 25 },
+];
+
+tidy(orders,
+  leftJoin(products, { by: 'productId' }),
+  mutate({ total: (d) => d.qty * d.price }),
+  arrange(desc('total'))
+)
+// => [
+//   { orderId: 2, productId: 'B', qty: 3, name: 'Gadget', price: 25, total: 75 },
+//   { orderId: 1, productId: 'A', qty: 5, name: 'Widget', price: 10, total: 50 },
+//   { orderId: 3, productId: 'A', qty: 2, name: 'Widget', price: 10, total: 20 },
+// ]
+```
+
+---
+
+## 9. Top-N Per Group
+
+Get the highest/lowest items within each group.
+
+```js
+const data = [
+  { category: 'A', name: 'a1', score: 90 },
+  { category: 'A', name: 'a2', score: 85 },
+  { category: 'A', name: 'a3', score: 70 },
+  { category: 'B', name: 'b1', score: 95 },
+  { category: 'B', name: 'b2', score: 60 },
+];
+
+// Top 2 per category
+tidy(data,
+  groupBy('category', [
+    arrange(desc('score')),
+    sliceHead(2),
+  ])
+)
+// => [
+//   { category: 'A', name: 'a1', score: 90 },
+//   { category: 'A', name: 'a2', score: 85 },
+//   { category: 'B', name: 'b1', score: 95 },
+//   { category: 'B', name: 'b2', score: 60 },
+// ]
+```
+
+**Alternative using sliceMax:**
+
+```js
+tidy(data,
+  groupBy('category', [
+    sliceMax(2, 'score'),
+  ])
+)
+```
+
+---
+
+## 10. Lag/Lead for Period-Over-Period Comparison
+
+Calculate change from previous period.
+
+```js
+const data = [
+  { month: 'Jan', revenue: 100 },
+  { month: 'Feb', revenue: 120 },
+  { month: 'Mar', revenue: 110 },
+];
+
+tidy(data,
+  mutateWithSummary({
+    prevRevenue: lag('revenue', { default: 0 }),
+  }),
+  mutate({
+    change: (d) => d.revenue - d.prevRevenue,
+    pctChange: (d) => d.prevRevenue ? (d.revenue - d.prevRevenue) / d.prevRevenue : null,
+  })
+)
+// => [
+//   { month: 'Jan', revenue: 100, prevRevenue: 0, change: 100, pctChange: null },
+//   { month: 'Feb', revenue: 120, prevRevenue: 100, change: 20, pctChange: 0.2 },
+//   { month: 'Mar', revenue: 110, prevRevenue: 120, change: -10, pctChange: -0.083 },
+// ]
+```

--- a/packages/tidy/genai-docs/quick-reference.md
+++ b/packages/tidy/genai-docs/quick-reference.md
@@ -1,0 +1,125 @@
+# Quick Reference
+
+Map common data tasks to the right tidyjs function.
+
+```js
+import { tidy, filter, mutate, mutateWithSummary, arrange, asc, desc,
+  select, distinct, rename, groupBy, summarize, count, tally,
+  sum, mean, median, min, max, n, nDistinct, first, last,
+  cumsum, lag, lead, roll, rowNumber,
+  innerJoin, leftJoin, fullJoin,
+  pivotWider, pivotLonger,
+  sliceHead, sliceTail, sliceMin, sliceMax, sliceSample,
+  complete, expand, fill, replaceNully, addRows, when, total,
+  everything, startsWith, endsWith, contains, matches,
+  rate, TMath } from '@tidyjs/tidy';
+```
+
+## Row Operations
+
+| I want to... | Use |
+|---|---|
+| Filter rows by condition | `filter((d) => d.value > 10)` |
+| Keep only unique rows | `distinct(['col1', 'col2'])` |
+| Sort rows ascending | `arrange(asc('name'))` or `arrange((d) => d.name)` |
+| Sort rows descending | `arrange(desc('value'))` |
+| Sort by multiple columns | `arrange(asc('category'), desc('value'))` |
+| Take first N rows | `sliceHead(5)` |
+| Take last N rows | `sliceTail(5)` |
+| Take rows with smallest values | `sliceMin(3, 'score')` |
+| Take rows with largest values | `sliceMax(3, 'score')` |
+| Take random sample | `sliceSample(10)` |
+| Take a range of rows | `slice(2, 5)` |
+| Add rows to the data | `addRows([{ name: 'new', value: 0 }])` |
+
+## Column Operations
+
+| I want to... | Use |
+|---|---|
+| Add or modify a column (per item) | `mutate({ newCol: (d) => d.a + d.b })` |
+| Add a column using cross-item calculation | `mutateWithSummary({ total: sum('value') })` |
+| Keep only certain columns | `select(['name', 'value'])` |
+| Drop specific columns | `select(['-password', '-secret'])` |
+| Select columns by prefix | `select([startsWith('revenue_')])` |
+| Select all columns except... | `select([everything(), '-internal'])` |
+| Rename columns | `rename({ oldName: 'newName' })` |
+| Keep only selected columns + transform | `transmute({ newCol: (d) => d.a * 2 })` |
+| Replace null/undefined values | `replaceNully({ score: 0, name: 'unknown' })` |
+| Set a constant value on all items | `mutate({ status: 'active' })` |
+
+## Aggregation
+
+| I want to... | Use |
+|---|---|
+| Sum a column | `summarize({ total: sum('value') })` |
+| Average a column | `summarize({ avg: mean('score') })` |
+| Find median | `summarize({ med: median('value') })` |
+| Find min/max | `summarize({ lo: min('val'), hi: max('val') })` |
+| Count rows | `summarize({ count: n() })` |
+| Count distinct values | `summarize({ unique: nDistinct('category') })` |
+| Get first/last value | `summarize({ start: first('date'), end: last('date') })` |
+| Standard deviation | `summarize({ sd: deviation('value') })` |
+| Variance | `summarize({ v: variance('value') })` |
+| Count shorthand | `count('category')` |
+| Tally rows | `tally()` |
+| Append a total row (keep originals) | `total({ value: sum('value') })` |
+
+## Grouping
+
+| I want to... | Use |
+|---|---|
+| Group and aggregate | `groupBy('key', [summarize({ total: sum('val') })])` |
+| Group by multiple keys | `groupBy(['cat', 'subcat'], [summarize(...)])` |
+| Group by computed key | `groupBy((d) => d.date.getFullYear(), [summarize(...)])` |
+| Get result as plain object | `groupBy('key', [ops], groupBy.object())` |
+| Get result as entries array | `groupBy('key', [ops], groupBy.entries())` |
+| Get result as Map | `groupBy('key', [ops], groupBy.map())` |
+| Get single item per group (after summarize) | `groupBy('key', [summarize(...)], groupBy.object({ single: true }))` |
+
+## Cross-Item Column Operations
+
+| I want to... | Use |
+|---|---|
+| Running total (cumulative sum) | `mutateWithSummary({ cum: cumsum('value') })` |
+| Previous row's value | `mutateWithSummary({ prev: lag('value') })` |
+| Next row's value | `mutateWithSummary({ next: lead('value') })` |
+| Rolling average (window of N) | `mutateWithSummary({ avg: roll(3, mean('value')) })` |
+| Row number / rank | `mutateWithSummary({ rank: rowNumber() })` |
+| Percentage of total | `mutateWithSummary({ pct: (items) => items.map(d => d.value / sum('value')(items)) })` |
+
+## Reshaping
+
+| I want to... | Use |
+|---|---|
+| Long to wide (pivot columns out) | `pivotWider({ namesFrom: 'key', valuesFrom: 'value' })` |
+| Wide to long (unpivot) | `pivotLonger({ cols: ['col1', 'col2'], namesTo: 'key', valuesTo: 'value' })` |
+| Fill missing combinations | `complete({ col1: ['a', 'b'], col2: [1, 2] })` |
+| Generate all combinations | `expand({ col1: ['a', 'b'], col2: [1, 2] })` |
+| Fill nulls forward (down) | `fill('column')` |
+
+## Joins
+
+| I want to... | Use |
+|---|---|
+| Inner join (matching rows only) | `innerJoin(otherData, { by: 'id' })` |
+| Left join (keep all left rows) | `leftJoin(otherData, { by: 'id' })` |
+| Full outer join | `fullJoin(otherData, { by: 'id' })` |
+| Join on different column names | `leftJoin(other, { by: { myId: 'theirId' } })` |
+
+## Conditional & Utility
+
+| I want to... | Use |
+|---|---|
+| Conditionally apply a transform | `when(condition, [filter(...)])` |
+| Apply a custom function to each item | `map((d) => ({ ...d, upper: d.name.toUpperCase() }))` |
+| Log intermediate pipeline state | `debug()` or `debug('label')` |
+| Calculate a rate per item | `mutate({ r: rate('num', 'denom') })` |
+| Simple math rate | `TMath.rate(numerator, denominator)` |
+
+## Aliases
+
+| Canonical | Alias |
+|---|---|
+| `arrange` | `sort` |
+| `select` | `pick` |
+| `addRows` | `addItems` |

--- a/packages/tidy/package.json
+++ b/packages/tidy/package.json
@@ -5,7 +5,8 @@
   "main": "dist/lib/index.js",
   "module": "dist/es/index.js",
   "files": [
-    "dist"
+    "dist",
+    "genai-docs"
   ],
   "types": "dist/tidy.d.ts",
   "typings": "dist/tidy.d.ts",

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: tidyjs
+description: Write correct, idiomatic tidyjs code. Activates when the user works with @tidyjs/tidy imports, mentions tidyjs, or asks about JavaScript data wrangling in a project that uses tidyjs.
+---
+
+**Before writing any tidyjs code, you MUST read the relevant docs.** tidyjs has a distinctive pipeline pattern and function taxonomy that differs from pandas, SQL, and lodash. Pre-training knowledge is often wrong for this library — always prefer the docs.
+
+## Locating the docs
+
+The genai-docs should be found at one of these locations. Check in order:
+
+1. **npm package**: `node_modules/@tidyjs/tidy/genai-docs/`
+
+If found, use that path as `DOCS_ROOT` below and proceed to **How to navigate**.
+
+### If docs are not found locally
+
+Fetch them from the public docs site. The AI-optimized docs are available at:
+
+`https://pbeshai.github.io/tidy/genai-docs/`
+
+The site also has `llms.txt` at `https://pbeshai.github.io/tidy/llms.txt` with a full index.
+
+Key files to fetch:
+- `https://pbeshai.github.io/tidy/genai-docs/mental-model.md` — start here
+- `https://pbeshai.github.io/tidy/genai-docs/quick-reference.md` — task-to-function lookup
+- `https://pbeshai.github.io/tidy/genai-docs/gotchas.md` — common mistakes
+- Then fetch specific `api-*.md` files as needed
+
+## How to navigate
+
+1. **Start**: Read `DOCS_ROOT/mental-model.md` for the pipeline pattern, accessor conventions, and function taxonomy. This is essential before writing any code.
+2. **Quick lookup**: Read `DOCS_ROOT/quick-reference.md` to find which function to use for a given task.
+3. **API details**: Read the relevant `api-*.md` file for function signatures, parameters, and examples:
+   - Core verbs (tidy, filter, mutate, arrange, select, etc.): `api-core.md`
+   - Grouping: `api-grouping.md`
+   - Summarize + aggregation functions: `api-summarize.md`
+   - Vector/cross-item operations: `api-vector.md`
+   - Joins: `api-joins.md`
+   - Pivoting: `api-pivot.md`
+   - Slicing: `api-slice.md`
+   - Column selectors: `api-selectors.md`
+   - Sequences: `api-sequences.md`
+   - Other (complete, expand, fill, TMath, etc.): `api-other.md`
+4. **Recipes**: Read `DOCS_ROOT/patterns.md` for multi-verb composition patterns.
+5. **Avoid mistakes**: Read `DOCS_ROOT/gotchas.md` before finalizing code.
+
+## Key principles
+
+- **Always read before writing**: Read the relevant api doc for every function you use.
+- **Pipeline pattern**: All transformations flow through `tidy(data, verb1(), verb2())`. Verbs are curried functions.
+- **Accessor functions, not strings**: Use `(d) => d.column` for field access, not string column names (except in summary functions like `sum('key')` and sort helpers like `desc('key')`).
+- **mutate vs mutateWithSummary**: `mutate` is per-item `(item, index, array) => value`. `mutateWithSummary` receives the full array `(items[]) => value[] | value`. Using summary/vector functions inside `mutate()` is a silent bug. Always check `gotchas.md` if unsure.
+- **groupBy export modes**: Without an export option, `groupBy` returns a flat array. With `groupBy.object()`, `.entries()`, `.map()`, etc., the output shape changes. Export modes must be the last pipeline step.
+- **Check the function taxonomy**: Summary functions go inside `summarize()`. Vector functions go inside `mutateWithSummary()`. Item functions go inside `mutate()`. Selectors go inside `select()`. Getting this wrong produces incorrect results.

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -20,3 +20,4 @@ yarn-debug.log*
 yarn-error.log*
 
 static/search-data.json
+static/genai-docs

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -70,6 +70,10 @@ module.exports = {
               label: 'GitHub Code Repository',
               href: 'https://github.com/pbeshai/tidy',
             },
+            {
+              label: 'AI Docs (genai-docs)',
+              href: 'https://pbeshai.github.io/tidy/genai-docs/index.md',
+            },
           ],
         },
       ],

--- a/website/package.json
+++ b/website/package.json
@@ -3,6 +3,8 @@
   "version": "2.6.0",
   "private": true,
   "scripts": {
+    "prebuild": "cp -r ../packages/tidy/genai-docs static/genai-docs",
+    "prestart": "cp -r ../packages/tidy/genai-docs static/genai-docs",
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -1,0 +1,41 @@
+# tidyjs
+
+> Tidy up your data with JavaScript! A data wrangling library inspired by R's dplyr and the tidyverse.
+
+## Docs
+
+- [Getting Started](https://pbeshai.github.io/tidy/docs/getting_started): Installation and basic usage
+- [API: Tidy Functions](https://pbeshai.github.io/tidy/docs/api/tidy): Core tidy verbs reference
+- [API: groupBy](https://pbeshai.github.io/tidy/docs/api/groupby): Grouping operations
+- [API: Summary Functions](https://pbeshai.github.io/tidy/docs/api/summary): Aggregation functions
+- [API: Vector Functions](https://pbeshai.github.io/tidy/docs/api/vector): Cross-item operations
+- [API: Pivot Functions](https://pbeshai.github.io/tidy/docs/api/pivot): Reshaping data
+- [API: Selectors](https://pbeshai.github.io/tidy/docs/api/selectors): Column selection helpers
+- [API: Sequences](https://pbeshai.github.io/tidy/docs/api/sequences): Sequence generation
+- [API: Math](https://pbeshai.github.io/tidy/docs/api/math): Math utilities
+- [API: Item Functions](https://pbeshai.github.io/tidy/docs/api/item): Per-item operations
+- [Playground](https://pbeshai.github.io/tidy/playground): Interactive playground
+
+## AI-Optimized Documentation
+
+- [Index](https://pbeshai.github.io/tidy/genai-docs/index.md): Entry point and file manifest for AI tools
+- [Mental Model](https://pbeshai.github.io/tidy/genai-docs/mental-model.md): Pipeline pattern, accessors, function taxonomy
+- [Quick Reference](https://pbeshai.github.io/tidy/genai-docs/quick-reference.md): Task-to-function cheat sheet
+- [Gotchas](https://pbeshai.github.io/tidy/genai-docs/gotchas.md): Common mistakes and anti-patterns
+- [Patterns](https://pbeshai.github.io/tidy/genai-docs/patterns.md): Multi-verb recipes
+- [API: Core](https://pbeshai.github.io/tidy/genai-docs/api-core.md): tidy, filter, mutate, arrange, select, etc.
+- [API: Grouping](https://pbeshai.github.io/tidy/genai-docs/api-grouping.md): groupBy + export modes
+- [API: Summarize](https://pbeshai.github.io/tidy/genai-docs/api-summarize.md): summarize + summary functions
+- [API: Vector](https://pbeshai.github.io/tidy/genai-docs/api-vector.md): mutateWithSummary + vector functions
+- [API: Joins](https://pbeshai.github.io/tidy/genai-docs/api-joins.md): innerJoin, leftJoin, fullJoin
+- [API: Pivot](https://pbeshai.github.io/tidy/genai-docs/api-pivot.md): pivotWider, pivotLonger
+- [API: Slice](https://pbeshai.github.io/tidy/genai-docs/api-slice.md): slice, sliceHead, sliceMax, etc.
+- [API: Selectors](https://pbeshai.github.io/tidy/genai-docs/api-selectors.md): everything, startsWith, etc.
+- [API: Sequences](https://pbeshai.github.io/tidy/genai-docs/api-sequences.md): fullSeq, fullSeqDate, etc.
+- [API: Other](https://pbeshai.github.io/tidy/genai-docs/api-other.md): complete, expand, fill, TMath, etc.
+
+## Optional
+
+- [GitHub Repository](https://github.com/pbeshai/tidy)
+- [npm Package](https://www.npmjs.com/package/@tidyjs/tidy)
+- [Observable Examples](https://observablehq.com/collection/@pbeshai/tidy-js)


### PR DESCRIPTION
## Summary

- Add `genai-docs/` bundle to `@tidyjs/tidy` — 15 markdown files (120KB) teaching AI assistants to write correct, idiomatic tidyjs code
- Add `llms.txt` at the docs site root for standard AI tool discovery
- Add Claude Code skill at `skill/SKILL.md` that references docs from npm or the public site
- Website prebuild copies genai-docs into `static/` so they're publicly accessible
- Footer link to genai-docs on the docs site

### What's in genai-docs/

| File | Purpose |
|------|---------|
| `mental-model.md` | Pipeline pattern, accessors, function taxonomy, mutate vs mutateWithSummary |
| `quick-reference.md` | Task-to-function cheat sheet (20+ mappings) |
| `gotchas.md` | 11 common AI mistakes with wrong-vs-right code |
| `patterns.md` | 10 multi-verb recipes (group+summarize, pivot, rolling, joins, etc.) |
| `api-*.md` (10 files) | All 70+ public functions with signatures, parameters, examples |
| `index.md` | Entry point and manifest for AI tools |

### Skill resolution order

1. `node_modules/@tidyjs/tidy/genai-docs/` (local npm)
2. `https://pbeshai.github.io/tidy/genai-docs/` (public fallback)

## Test plan

- [ ] `npm pack` in `packages/tidy/` includes `genai-docs/` in the tarball
- [ ] `npm run build` in `website/` copies genai-docs to `static/` and builds successfully
- [ ] `llms.txt` and `genai-docs/index.md` are accessible on the deployed site
- [ ] Give an AI the mental-model.md + relevant api doc and ask it to write a filter+groupBy+summarize pipeline — verify it produces correct code

🤖 Generated with [Claude Code](https://claude.com/claude-code)